### PR TITLE
Handle malformed CSV rows in FormatHelper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
             <artifactId>json</artifactId>
             <version>20250107</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -59,6 +66,14 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/se/goencoder/loppiskassan/records/FormatHelperTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/records/FormatHelperTest.java
@@ -1,0 +1,36 @@
+package se.goencoder.loppiskassan.records;
+
+import org.junit.jupiter.api.Test;
+import se.goencoder.loppiskassan.SoldItem;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FormatHelperTest {
+
+    @Test
+    void skipsMalformedLineWithTooFewColumns() {
+        String csv = FormatHelper.CVS_HEADERS + FormatHelper.LINE_ENDING +
+                "p1,i1,2024-01-01 10:00,1,100";
+        List<SoldItem> items = FormatHelper.toItems(csv, true);
+        assertTrue(items.isEmpty(), "Malformed line should be skipped");
+    }
+
+    @Test
+    void skipsInvalidPaymentMethod() {
+        String line = String.join(",", "p1", "i1", "2024-01-01 10:00", "1", "100", "Nej", "INVALID", "false");
+        String csv = FormatHelper.CVS_HEADERS + FormatHelper.LINE_ENDING + line;
+        List<SoldItem> items = FormatHelper.toItems(csv, true);
+        assertTrue(items.isEmpty(), "Line with invalid payment method should be skipped");
+    }
+
+    @Test
+    void skipsInvalidUploadedFlag() {
+        String line = String.join(",", "p1", "i1", "2024-01-01 10:00", "1", "100", "Nej", "Swish", "notabool");
+        String csv = FormatHelper.CVS_HEADERS + FormatHelper.LINE_ENDING + line;
+        List<SoldItem> items = FormatHelper.toItems(csv, true);
+        assertTrue(items.isEmpty(), "Line with invalid uploaded flag should be skipped");
+    }
+}
+


### PR DESCRIPTION
## Summary
- validate CSV column count before reading collected time, payment method, or upload flag
- skip rows with unknown payment methods or invalid boolean flags
- add unit tests for malformed lines and payment method errors

## Testing
- `make install-client`
- `make build` *(fails: Invalid or unsupported type: [dmg])* 
- `mvn test`
- `make run` *(fails: HeadlessException)*
- `make verify` *(fails: Invalid or unsupported type: [dmg])* 
- `make security` *(fails: interrupted Error 130)*

------
https://chatgpt.com/codex/tasks/task_e_68a458fd2e608324a420b2b844a97591