### PR TITLE
Add localization manager and language selector

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/Main.java
+++ b/src/main/java/se/goencoder/loppiskassan/Main.java
@@ -2,6 +2,7 @@ package se.goencoder.loppiskassan;
 
 
 import se.goencoder.loppiskassan.records.FileHelper;
+import se.goencoder.loppiskassan.localization.LocalizationManager;
 import se.goencoder.loppiskassan.ui.Popup;
 import se.goencoder.loppiskassan.ui.UserInterface;
 
@@ -19,7 +20,7 @@ public class Main {
      */
     private static void createAndShowGUI() {
         UserInterface frame = new UserInterface();
-        frame.setTitle("iLoppis Kassahantering v1.0");
+        frame.setTitle(LocalizationManager.tr("frame.title"));
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
         // Ställ in ramens storlek och gör den synlig
@@ -67,9 +68,8 @@ public class Main {
             // We have no logs yet, so we dump the error to the console
             e.printStackTrace();
             Popup.FATAL.showAndWait(
-                    "Kunde inte skapa kataloger",
-                    "Behöver skapa kataloger 'data' och 'logs' för att fortsätta." +
-                            "Kontrollera att programmet har rättigheter att skapa kataloger.");
+                    LocalizationManager.tr("error.create_dirs.title"),
+                    LocalizationManager.tr("error.create_dirs.message"));
         }
     }
 }

--- a/src/main/java/se/goencoder/loppiskassan/localization/JsonLocalizationStrategy.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/JsonLocalizationStrategy.java
@@ -1,0 +1,36 @@
+package se.goencoder.loppiskassan.localization;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Loads translations from JSON files located in {@code /lang} on the classpath.
+ */
+public class JsonLocalizationStrategy implements LocalizationStrategy {
+    private final JSONObject translations;
+
+    public JsonLocalizationStrategy(String languageCode) {
+        this.translations = load(languageCode);
+    }
+
+    private JSONObject load(String languageCode) {
+        String path = "/lang/" + languageCode + ".json";
+        try (InputStream is = JsonLocalizationStrategy.class.getResourceAsStream(path)) {
+            if (is == null) {
+                throw new IllegalArgumentException("Missing language file: " + path);
+            }
+            String text = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            return new JSONObject(text);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not load language file " + path, e);
+        }
+    }
+
+    @Override
+    public String get(String key) {
+        return translations.optString(key, key);
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/localization/LocalizationManager.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/LocalizationManager.java
@@ -1,0 +1,31 @@
+package se.goencoder.loppiskassan.localization;
+
+import java.text.MessageFormat;
+
+/**
+ * Singleton manager for localization. Uses a {@link LocalizationStrategy}
+ * to retrieve translations. The default language is Swedish.
+ */
+public final class LocalizationManager {
+    private static LocalizationStrategy strategy = new JsonLocalizationStrategy("sv");
+
+    private LocalizationManager() {}
+
+    /**
+     * Changes the current language.
+     *
+     * @param languageCode ISO language code (e.g. "sv", "en")
+     */
+    public static void setLanguage(String languageCode) {
+        strategy = new JsonLocalizationStrategy(languageCode);
+    }
+
+    /**
+     * Returns the translation for the given key, formatting using
+     * {@link MessageFormat} when arguments are provided.
+     */
+    public static String tr(String key, Object... args) {
+        String value = strategy.get(key);
+        return args.length > 0 ? MessageFormat.format(value, args) : value;
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/localization/LocalizationStrategy.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/LocalizationStrategy.java
@@ -1,0 +1,14 @@
+package se.goencoder.loppiskassan.localization;
+
+/**
+ * Strategy interface for providing translations.
+ */
+public interface LocalizationStrategy {
+    /**
+     * Returns the translation for the given key.
+     *
+     * @param key translation key
+     * @return translated string or the key itself if missing
+     */
+    String get(String key);
+}

--- a/src/main/java/se/goencoder/loppiskassan/ui/Popup.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/Popup.java
@@ -8,6 +8,8 @@ import java.io.StringWriter;
 import java.util.Objects;
 import java.util.logging.Logger;
 
+import se.goencoder.loppiskassan.localization.LocalizationManager;
+
 
 /**
  * Enum representing different types of popup windows that can be displayed in the Loppiskassan Swing application.
@@ -75,7 +77,7 @@ public enum Popup {
      */
     public boolean showConfirmDialog(String title, String message) {
         // Customize button texts as needed
-        Object[] options = {"Bekräfta", "Avbryt"};
+        Object[] options = {LocalizationManager.tr("popup.confirm"), LocalizationManager.tr("popup.cancel")};
         int result = JOptionPane.showOptionDialog(null, message, title,
                 JOptionPane.DEFAULT_OPTION, messageType,
                 null, options, options[0]);

--- a/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
@@ -1,6 +1,7 @@
 package se.goencoder.loppiskassan.ui;
 
 import se.goencoder.loppiskassan.config.ConfigurationStore;
+import se.goencoder.loppiskassan.localization.LocalizationManager;
 
 import javax.swing.*;
 import java.awt.*;
@@ -29,8 +30,8 @@ public class UserInterface extends JFrame {
                 case 2 -> HISTORY;
                 default -> {
                     Popup.FATAL.showAndWait(
-                            "Denna tabb finns inte",
-                            "Det finns ingen tabb med index " + index);
+                            LocalizationManager.tr("error.no_tab"),
+                            LocalizationManager.tr("error.no_tab_index", index));
                     yield CASHIER;
                 }
             };
@@ -38,6 +39,7 @@ public class UserInterface extends JFrame {
     }
 
     public UserInterface() {
+        setLayout(new BorderLayout());
         tabPane = new JTabbedPane();
         initializeTabs();
 
@@ -51,16 +53,17 @@ public class UserInterface extends JFrame {
                 if (ConfigurationStore.EVENT_ID_STR.get() == null) {
                     tabPane.setSelectedIndex(SELECTABLE_TABS.DISCOVERY.getIndex());
                     Popup.ERROR.showAndWait(
-                            "Ingen loppis vald",
-                            "Vänligen välj en loppis att öppna en kassa för först.");
+                            LocalizationManager.tr("error.no_event_selected.title"),
+                            LocalizationManager.tr("error.no_event_selected.message"));
                     return;
                 }
             }
             selectabableTabs.get(selectedTab.getIndex()).selected();
         });
 
-        add(tabPane);
-        setTitle("Loppiskassan");
+        add(createLanguagePanel(), BorderLayout.NORTH);
+        add(tabPane, BorderLayout.CENTER);
+        reloadTexts();
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         setSize(900, 600);
         setLocationRelativeTo(null);
@@ -73,19 +76,49 @@ public class UserInterface extends JFrame {
         return button;
     }
 
+    private JPanel createLanguagePanel() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        JButton sv = new JButton("\uD83C\uDDF8\uD83C\uDDEA");
+        sv.setBorderPainted(false);
+        sv.setContentAreaFilled(false);
+        sv.addActionListener(e -> {
+            LocalizationManager.setLanguage("sv");
+            reloadTexts();
+        });
+        JButton en = new JButton("\uD83C\uDDEC\uD83C\uDDE7");
+        en.setBorderPainted(false);
+        en.setContentAreaFilled(false);
+        en.addActionListener(e -> {
+            LocalizationManager.setLanguage("en");
+            reloadTexts();
+        });
+        panel.add(sv);
+        panel.add(en);
+        return panel;
+    }
+
+    private void reloadTexts() {
+        setTitle(LocalizationManager.tr("frame.title"));
+        tabPane.setTitleAt(0, LocalizationManager.tr("tab.discovery"));
+        tabPane.setToolTipTextAt(0, LocalizationManager.tr("tab.discovery.tooltip"));
+        tabPane.setTitleAt(1, LocalizationManager.tr("tab.cashier"));
+        tabPane.setToolTipTextAt(1, LocalizationManager.tr("tab.cashier.tooltip"));
+        tabPane.setTitleAt(2, LocalizationManager.tr("tab.history"));
+        tabPane.setToolTipTextAt(2, LocalizationManager.tr("tab.history.tooltip"));
+    }
+
     private void initializeTabs() {
         DiscoveryTabPanel discoveryTabPanel = new DiscoveryTabPanel();
-        tabPane.addTab("Välj Loppis", null, discoveryTabPanel, "Välj vilken loppis du vill öppna en kassa för");
+        tabPane.addTab("", null, discoveryTabPanel, "");
         selectabableTabs.add(discoveryTabPanel);
 
         CashierTabPanel cashierTabPanel = new CashierTabPanel();
-        tabPane.addTab("Kassahantering", null, cashierTabPanel, "Hantera kassatransaktioner");
+        tabPane.addTab("", null, cashierTabPanel, "");
         selectabableTabs.add(cashierTabPanel);
 
         HistoryTabPanel historyTabPanel = new HistoryTabPanel();
-        tabPane.addTab("Historik", null, historyTabPanel, "Visa tidigare transaktioner");
+        tabPane.addTab("", null, historyTabPanel, "");
         selectabableTabs.add(historyTabPanel);
     }
-
 
 }

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -1,0 +1,17 @@
+{
+  "tab.discovery": "Select Event",
+  "tab.discovery.tooltip": "Select which event to open a cash register for",
+  "tab.cashier": "Cashier",
+  "tab.cashier.tooltip": "Handle cash register transactions",
+  "tab.history": "History",
+  "tab.history.tooltip": "View past transactions",
+  "error.no_tab": "This tab does not exist",
+  "error.no_tab_index": "There is no tab with index {0}",
+  "error.no_event_selected.title": "No event selected",
+  "error.no_event_selected.message": "Please select an event before opening a cash register.",
+  "frame.title": "iLoppis Cash Register v1.0",
+  "popup.confirm": "Confirm",
+  "popup.cancel": "Cancel",
+  "error.create_dirs.title": "Could not create directories",
+  "error.create_dirs.message": "Need to create directories 'data' and 'logs' to continue. Ensure the program has permission to create directories."
+}

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -1,0 +1,17 @@
+{
+  "tab.discovery": "Välj Loppis",
+  "tab.discovery.tooltip": "Välj vilken loppis du vill öppna en kassa för",
+  "tab.cashier": "Kassahantering",
+  "tab.cashier.tooltip": "Hantera kassatransaktioner",
+  "tab.history": "Historik",
+  "tab.history.tooltip": "Visa tidigare transaktioner",
+  "error.no_tab": "Denna tabb finns inte",
+  "error.no_tab_index": "Det finns ingen tabb med index {0}",
+  "error.no_event_selected.title": "Ingen loppis vald",
+  "error.no_event_selected.message": "Vänligen välj en loppis att öppna en kassa för först.",
+  "frame.title": "iLoppis Kassahantering v1.0",
+  "popup.confirm": "Bekräfta",
+  "popup.cancel": "Avbryt",
+  "error.create_dirs.title": "Kunde inte skapa kataloger",
+  "error.create_dirs.message": "Behöver skapa kataloger 'data' och 'logs' för att fortsätta. Kontrollera att programmet har rättigheter att skapa kataloger."
+}


### PR DESCRIPTION
## Summary
- add Strategy-based localization manager with JSON language files
- translate UI strings and error messages into English and Swedish
- add flag buttons to switch languages at runtime

## Testing
- `make build-codex`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a4c57d822c83248a59455226098a0f