### PR TITLE
feat: introduce centralized FlatLaf theming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,17 @@
             <artifactId>json</artifactId>
             <version>20250107</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>flatlaf</artifactId>
+            <version>3.4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.formdev</groupId>
+            <artifactId>flatlaf-extras</artifactId>
+            <version>3.4.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/se/goencoder/loppiskassan/Main.java
+++ b/src/main/java/se/goencoder/loppiskassan/Main.java
@@ -5,6 +5,7 @@ import se.goencoder.loppiskassan.records.FileHelper;
 import se.goencoder.loppiskassan.localization.LocalizationManager;
 import se.goencoder.loppiskassan.ui.Popup;
 import se.goencoder.loppiskassan.ui.UserInterface;
+import se.goencoder.loppiskassan.ui.Theme;
 
 import javax.swing.*;
 import java.io.IOException;
@@ -19,6 +20,7 @@ public class Main {
      * Initierar och visar huvudfönstret för Swing-applikationen.
      */
     private static void createAndShowGUI() {
+        Theme.install(); // Install look & feel before creating components
         UserInterface frame = new UserInterface();
         frame.setTitle(LocalizationManager.tr("frame.title"));
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);

--- a/src/main/java/se/goencoder/loppiskassan/ui/Theme.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/Theme.java
@@ -1,0 +1,91 @@
+package se.goencoder.loppiskassan.ui;
+
+import com.formdev.flatlaf.FlatDarkLaf;
+import com.formdev.flatlaf.FlatLightLaf;
+
+import javax.swing.*;
+import java.awt.*;
+
+/**
+ * Single place for all UI look & feel knobs.
+ * Tweak the public static fields below to control the whole app style.
+ *
+ * System props (optional overrides):
+ *  -Diloppis.theme=dark|light
+ *  -Diloppis.ui.scale=125   (percent; sets flatlaf.uiScale)
+ */
+public final class Theme {
+
+    // ---- Control knobs (edit these) ----------------------------------------
+    public static boolean FOLLOW_OS = false;      // true requires flatlaf-system-extensions (not used yet)
+    public static boolean DARK_DEFAULT = false;   // app default if FOLLOW_OS is false or not supported
+
+    public static int COMPONENT_ARC = 16;
+    public static int BUTTON_ARC    = 20;
+    public static int TEXT_ARC      = 12;
+    public static int FOCUS_WIDTH   = 1;
+
+    public static boolean SCROLLBAR_BUTTONS = false;
+    public static boolean TABLE_STRIPES     = true;
+
+    /** Optional brand accent for focus & selection; set to null to use default. */
+    public static Color ACCENT = null; // e.g. new Color(0x228BE6);
+
+    /** Optional global UI scale in percent (0 = off). Can also be set via -Diloppis.ui.scale=125 */
+    public static int UI_SCALE_PERCENT = Integer.getInteger("iloppis.ui.scale", 0);
+    // ------------------------------------------------------------------------
+
+    private Theme() {}
+
+    /** Install LAF and apply all UI defaults. Call once before creating any Swing components. */
+    public static void install() {
+        // Optional scaling
+        if (UI_SCALE_PERCENT > 0) {
+            System.setProperty("flatlaf.uiScale", UI_SCALE_PERCENT + "%");
+        }
+
+        // Determine dark/light via system prop or defaults
+        String forced = System.getProperty("iloppis.theme", null); // "dark"|"light"|null
+        boolean useDark = forced != null ? forced.equalsIgnoreCase("dark") : DARK_DEFAULT;
+
+        try {
+            UIManager.setLookAndFeel(useDark ? new FlatDarkLaf() : new FlatLightLaf());
+        } catch (UnsupportedLookAndFeelException ignore) {
+            // Keep whatever LAF is available; still apply some defaults below.
+        }
+
+        // Global style tweaks
+        UIManager.put("Component.arc", COMPONENT_ARC);
+        UIManager.put("Button.arc", BUTTON_ARC);
+        UIManager.put("TextComponent.arc", TEXT_ARC);
+        UIManager.put("Component.focusWidth", FOCUS_WIDTH);
+
+        UIManager.put("ScrollBar.showButtons", SCROLLBAR_BUTTONS);
+
+        UIManager.put("Table.showHorizontalLines", false);
+        UIManager.put("Table.showVerticalLines", false);
+        if (TABLE_STRIPES) {
+            // FlatLaf provides alternate row coloring automatically; keep default striping on.
+            // (No explicit setting needed; left here as a reminder knob.)
+        }
+
+        if (ACCENT != null) {
+            UIManager.put("Component.focusColor", ACCENT);
+            UIManager.put("Button.default.focusColor", ACCENT);
+            UIManager.put("ScrollBar.thumbHoverBorderColor", ACCENT);
+        }
+    }
+
+    /**
+     * Switch theme at runtime, if needed later (not wired to UI yet).
+     * Call with `true` for dark, `false` for light.
+     */
+    public static void switchTheme(Window root, boolean dark) {
+        try {
+            UIManager.setLookAndFeel(dark ? new FlatDarkLaf() : new FlatLightLaf());
+            SwingUtilities.updateComponentTreeUI(root);
+            root.pack();
+        } catch (UnsupportedLookAndFeelException ignore) { }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FlatLaf and FlatLaf extras dependencies
- introduce `Theme` manager to centralize UI styling knobs and LAF install/switch logic
- install theme during application startup

## Testing
- `make build-codex`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a5799afcbc83249c28bedaf76dae15