### PR TITLE
Improve language selector with HiDPI flags

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/ui/UiKnobs.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UiKnobs.java
@@ -1,15 +1,24 @@
 package se.goencoder.loppiskassan.ui;
 
-/**
- * Centralt ställe för UI-inställningar/"kontrollknoppar".
- * Justera här utan att behöva gräva i komponentkoden.
- */
+import java.awt.*;
+
 public final class UiKnobs {
     private UiKnobs() {}
 
-    // Språkväljaren - Display options
-    public static int LANG_ICON_SIZE_PX = 24;          // Size of PNG flag icons
-    public static boolean LANG_BUTTON_SHOW_TEXT = false; // Show text in closed combobox (false for clean "flag + caret" look)
-    public static boolean LANG_POPUP_SHOW_TEXT = true;   // Show language text in popup list
-    public static String LANG_FLAGS_PATH = "/flags/"; // Path to PNG flag icons
+    // Language selector sizing
+    public static final int LANG_SELECTOR_MIN_WIDTH = 160; // wide enough for longest label
+    public static final int LANG_SELECTOR_HEIGHT    = 32;
+
+    // Flag icon box (kept non-square; the icon renderer preserves AR inside this box)
+    public static final int FLAG_W = 24;  // logical px
+    public static final int FLAG_H = 16;  // 3:2 ratio
+
+    // Spacing & typography
+    public static final int LANG_ICON_TEXT_GAP = 8;
+    public static final Insets LANG_CELL_PADDING = new Insets(4, 8, 4, 8);
+    public static final Font LANG_FONT = new Font("SansSerif", Font.PLAIN, 13);
+
+    // Popup list row height (enough for icon + padding)
+    public static final int LANG_LIST_ROW_HEIGHT = 24;
 }
+

--- a/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
@@ -79,11 +79,14 @@ public class UserInterface extends JFrame implements LocalizationAware {
     }
 
     private JPanel createLanguagePanel() {
-        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 6));
+        JPanel panel = new JPanel();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
         panel.setOpaque(false);
-        // Drop-in språkväljare (flag + caret). Läs/skriv ev. persisterat val i ConfigurationStore om du vill.
-        LanguageSelector selector = new LanguageSelector();
-        panel.add(selector);
+
+        panel.add(Box.createHorizontalGlue());
+        panel.add(new LanguageSelector());
+        panel.add(Box.createHorizontalStrut(8));
+
         return panel;
     }
 

--- a/src/main/java/se/goencoder/loppiskassan/ui/icons/FlagIcon.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/icons/FlagIcon.java
@@ -1,0 +1,57 @@
+package se.goencoder.loppiskassan.ui.icons;
+
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BaseMultiResolutionImage;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class FlagIcon implements Icon {
+    private final Image multiResImage;
+    private final int targetW;
+    private final int targetH;
+
+    public FlagIcon(String resourceBaseName, int targetW, int targetH) {
+        this.targetW = targetW;
+        this.targetH = targetH;
+
+        BufferedImage img1x = load(resourceBaseName + "@1x.png");
+        BufferedImage img2x = load(resourceBaseName + "@2x.png");
+
+        this.multiResImage = new BaseMultiResolutionImage(img1x, img2x);
+    }
+
+    private static BufferedImage load(String path) {
+        try (InputStream is = FlagIcon.class.getClassLoader().getResourceAsStream(path)) {
+            if (is == null) throw new IllegalArgumentException("Missing resource: " + path);
+            return ImageIO.read(is);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot read resource: " + path, e);
+        }
+    }
+
+    @Override public int getIconWidth() { return targetW; }
+    @Override public int getIconHeight() { return targetH; }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        g2.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+        int boxW = targetW, boxH = targetH;
+        int srcW = multiResImage.getWidth(null), srcH = multiResImage.getHeight(null);
+        double scale = Math.min((double) boxW / srcW, (double) boxH / srcH);
+        int drawW = (int) Math.round(srcW * scale);
+        int drawH = (int) Math.round(srcH * scale);
+        int dx = x + (boxW - drawW) / 2;
+        int dy = y + (boxH - drawH) / 2;
+
+        g2.drawImage(multiResImage, dx, dy, drawW, drawH, null);
+        g2.dispose();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add scalable `FlagIcon` that selects best resolution on HiDPI displays
- centralize language selector sizes and fonts in `UiKnobs`
- rebuild `LanguageSelector` and wire into `UserInterface`

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `mvn -q test -e` *(fails: java.nio.file.NoSuchFileException: data/loppiskassan.csv)*
- `mvn -q verify -e` *(fails: java.nio.file.NoSuchFileException: data/loppiskassan.csv)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e79062688324a0335cea2a922ebf