### PR TITLE
feat: compact language popup selector

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/ui/LanguageSelector.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/LanguageSelector.java
@@ -2,90 +2,138 @@ package se.goencoder.loppiskassan.ui;
 
 import se.goencoder.loppiskassan.localization.LocalizationManager;
 import se.goencoder.loppiskassan.ui.icons.FlagIcon;
+import se.goencoder.loppiskassan.ui.icons.ChevronDownIcon;
 
 import javax.swing.*;
-import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import java.awt.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public final class LanguageSelector extends JPanel {
     public static final class LanguageItem {
         public final String code;      // "sv" or "en"
-        public final String labelKey;  // "language.swedish" / "language.english"
-        public final Icon icon;
+        public final String labelKey;  // "language.swedish"/"language.english"
+        public final Icon   flagIcon;
 
-        public LanguageItem(String code, String labelKey, Icon icon) {
+        public LanguageItem(String code, String labelKey, Icon flagIcon) {
             this.code = code;
             this.labelKey = labelKey;
-            this.icon = icon;
+            this.flagIcon = flagIcon;
         }
 
-        @Override public String toString() { return LocalizationManager.tr(labelKey); }
+        public String label() { return LocalizationManager.tr(labelKey); }
     }
 
-    private final JComboBox<LanguageItem> combo;
+    private final JButton trigger = new JButton();
+    private final JPopupMenu menu = new JPopupMenu();
+    private final Map<String, LanguageItem> items = new LinkedHashMap<>();
 
     public LanguageSelector() {
         setLayout(new BorderLayout());
+        setOpaque(false);
 
-        LanguageItem sv = new LanguageItem(
-                "sv", "language.swedish",
-                new FlagIcon("flags/se", UiKnobs.FLAG_W, UiKnobs.FLAG_H)
-        );
-        LanguageItem en = new LanguageItem(
-                "en", "language.english",
-                new FlagIcon("flags/gb", UiKnobs.FLAG_W, UiKnobs.FLAG_H)
-        );
+        // Build models (keep insertion order for menu)
+        items.put("sv", new LanguageItem("sv", "language.swedish",
+                new FlagIcon("flags/se", UiKnobs.FLAG_W, UiKnobs.FLAG_H)));
+        items.put("en", new LanguageItem("en", "language.english",
+                new FlagIcon("flags/gb", UiKnobs.FLAG_W, UiKnobs.FLAG_H)));
 
-        combo = new JComboBox<>(new DefaultComboBoxModel<>(new LanguageItem[]{ sv, en }));
-        combo.setFont(UiKnobs.LANG_FONT);
-        combo.setMaximumRowCount(6);
-        combo.setRenderer(new FlagRenderer());
-        combo.setPrototypeDisplayValue(en); // ensures width for longest label
-        combo.setPreferredSize(new Dimension(
-                Math.max(UiKnobs.LANG_SELECTOR_MIN_WIDTH, combo.getPreferredSize().width),
-                UiKnobs.LANG_SELECTOR_HEIGHT
-        ));
+        // Button visuals: only flag + chevron, compact, no text
+        trigger.setFocusable(false);
+        trigger.setRequestFocusEnabled(false);
+        trigger.setMargin(UiKnobs.LANG_BUTTON_MARGIN);
+        trigger.setFont(UiKnobs.LANG_FONT);
+        trigger.setHorizontalAlignment(SwingConstants.LEFT);
 
-        String cur = getCurrentLanguageCode();
-        combo.setSelectedItem("en".equals(cur) ? en : sv);
+        // Slightly rounded button on most LAFs
+        Dimension pref = new Dimension(UiKnobs.LANG_BUTTON_MIN_W, UiKnobs.LANG_BUTTON_HEIGHT);
+        trigger.setPreferredSize(pref);
+        trigger.setMinimumSize(pref);
 
-        combo.addActionListener(e -> {
-            LanguageItem li = (LanguageItem) combo.getSelectedItem();
-            if (li != null) LocalizationManager.setLanguage(li.code);
+        trigger.addActionListener(e -> {
+            if (!menu.isVisible()) {
+                menu.show(trigger, 0, trigger.getHeight());
+            } else {
+                menu.setVisible(false);
+            }
         });
 
-        add(combo, BorderLayout.CENTER);
+        rebuildMenu();
+        updateTriggerForCurrentLanguage();
+
+        add(trigger, BorderLayout.CENTER);
     }
 
-    private static String getCurrentLanguageCode() {
-        return "sv"; // default
-    }
-
-    private static final class FlagRenderer extends BasicComboBoxRenderer {
-        @Override
-        public Component getListCellRendererComponent(
-                JList list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
-
-            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-
-            LanguageItem item = (LanguageItem) value;
-            setIcon(item.icon);
-            setText(LocalizationManager.tr(item.labelKey));
-            setFont(UiKnobs.LANG_FONT);
-            setBorder(BorderFactory.createEmptyBorder(
-                    UiKnobs.LANG_CELL_PADDING.top,
-                    UiKnobs.LANG_CELL_PADDING.left,
-                    UiKnobs.LANG_CELL_PADDING.bottom,
-                    UiKnobs.LANG_CELL_PADDING.right
+    private void rebuildMenu() {
+        menu.removeAll();
+        menu.setBorder(BorderFactory.createEmptyBorder(4, 0, 4, 0));
+        for (LanguageItem it : items.values()) {
+            JCheckBoxMenuItem mi = new JCheckBoxMenuItem(it.label());
+            mi.setIcon(it.flagIcon);
+            mi.setFont(UiKnobs.LANG_FONT);
+            mi.setMargin(UiKnobs.LANG_POPUP_ITEM_PAD);
+            mi.setIconTextGap(UiKnobs.LANG_ICON_TEXT_GAP);
+            mi.setSelected(it.code.equals(currentLanguage()));
+            mi.addActionListener(e -> {
+                if (!it.code.equals(currentLanguage())) {
+                    LocalizationManager.setLanguage(it.code);
+                    updateTriggerForCurrentLanguage();
+                    // keep menu open only briefly so click feedback is visible
+                }
+                menu.setVisible(false);
+            });
+            // Keep rows consistent height
+            mi.setPreferredSize(new Dimension(
+                    Math.max(mi.getPreferredSize().width, 160),
+                    UiKnobs.LANG_POPUP_ROW_HEIGHT + UiKnobs.LANG_POPUP_ITEM_PAD.top + UiKnobs.LANG_POPUP_ITEM_PAD.bottom
             ));
-            setIconTextGap(UiKnobs.LANG_ICON_TEXT_GAP);
+            menu.add(mi);
+        }
+    }
 
-            if (list != null && list.getFixedCellHeight() != UiKnobs.LANG_LIST_ROW_HEIGHT) {
-                list.setFixedCellHeight(UiKnobs.LANG_LIST_ROW_HEIGHT);
-            }
+    private void updateTriggerForCurrentLanguage() {
+        LanguageItem active = items.getOrDefault(currentLanguage(), items.get("sv"));
+        // Compose flag + chevron
+        trigger.setIcon(active.flagIcon);
+        trigger.setText(null); // collapsed state: no label
+        trigger.setDisabledIcon(active.flagIcon);
+        trigger.setToolTipText(active.label());
 
-            return this;
+        // Place a chevron on the right via compound icon (using button's "disabled" area is overkill).
+        // Simpler: set a right-side icon via HTML gap — or draw in paintComponent.
+        // We'll add a small secondary icon via setRolloverIcon for visual hint.
+        trigger.setRolloverIcon(new CompoundIcon(active.flagIcon, new ChevronDownIcon(10, 10)));
+        trigger.setIcon(new CompoundIcon(active.flagIcon, new ChevronDownIcon(10, 10)));
+        // Ensure menu reflects selection after i18n change
+        rebuildMenu();
+        revalidate();
+        repaint();
+    }
+
+    private static String currentLanguage() {
+        // If you persist language elsewhere, hook it here.
+        // Default to "sv" to match existing behavior.
+        return "sv";
+    }
+
+    // Helper to paint two icons side-by-side (flag + chevron)
+    private static final class CompoundIcon implements Icon {
+        private final Icon left, right;
+        private final int gap;
+
+        CompoundIcon(Icon left, Icon right) { this(left, right, 6); }
+        CompoundIcon(Icon left, Icon right, int gap) { this.left = left; this.right = right; this.gap = gap; }
+
+        @Override public int getIconWidth() { return left.getIconWidth() + gap + right.getIconWidth(); }
+        @Override public int getIconHeight() { return Math.max(left.getIconHeight(), right.getIconHeight()); }
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            int cy = y + (getIconHeight() - left.getIconHeight()) / 2;
+            left.paintIcon(c, g, x, cy);
+            int x2 = x + left.getIconWidth() + gap;
+            cy = y + (getIconHeight() - right.getIconHeight()) / 2;
+            right.paintIcon(c, g, x2, cy);
         }
     }
 }
-

--- a/src/main/java/se/goencoder/loppiskassan/ui/UiKnobs.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UiKnobs.java
@@ -5,20 +5,23 @@ import java.awt.*;
 public final class UiKnobs {
     private UiKnobs() {}
 
-    // Language selector sizing
-    public static final int LANG_SELECTOR_MIN_WIDTH = 160; // wide enough for longest label
-    public static final int LANG_SELECTOR_HEIGHT    = 32;
+    // Language button (collapsed) – compact
+    public static final int LANG_BUTTON_HEIGHT   = 28;
+    public static final int LANG_BUTTON_MIN_W    = 56; // flag + chevron
+    public static final Insets LANG_BUTTON_MARGIN = new Insets(2, 6, 2, 6);
 
-    // Flag icon box (kept non-square; the icon renderer preserves AR inside this box)
-    public static final int FLAG_W = 24;  // logical px
-    public static final int FLAG_H = 16;  // 3:2 ratio
+    // Popup list
+    public static final int LANG_POPUP_ROW_HEIGHT = 24;
+    public static final Insets LANG_POPUP_ITEM_PAD = new Insets(4, 8, 4, 8);
 
-    // Spacing & typography
-    public static final int LANG_ICON_TEXT_GAP = 8;
-    public static final Insets LANG_CELL_PADDING = new Insets(4, 8, 4, 8);
+    // Typography
     public static final Font LANG_FONT = new Font("SansSerif", Font.PLAIN, 13);
 
-    // Popup list row height (enough for icon + padding)
-    public static final int LANG_LIST_ROW_HEIGHT = 24;
+    // Flag box (renderer will preserve 3:2 aspect)
+    public static final int FLAG_W = 24;
+    public static final int FLAG_H = 16;
+
+    // Spacing between icon and text
+    public static final int LANG_ICON_TEXT_GAP = 8;
 }
 

--- a/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UserInterface.java
@@ -79,13 +79,11 @@ public class UserInterface extends JFrame implements LocalizationAware {
     }
 
     private JPanel createLanguagePanel() {
-        JPanel panel = new JPanel();
-        panel.setLayout(new BoxLayout(panel, BoxLayout.X_AXIS));
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT, 8, 6));
         panel.setOpaque(false);
 
-        panel.add(Box.createHorizontalGlue());
-        panel.add(new LanguageSelector());
-        panel.add(Box.createHorizontalStrut(8));
+        LanguageSelector selector = new LanguageSelector();
+        panel.add(selector);
 
         return panel;
     }

--- a/src/main/java/se/goencoder/loppiskassan/ui/icons/ChevronDownIcon.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/icons/ChevronDownIcon.java
@@ -1,0 +1,30 @@
+package se.goencoder.loppiskassan.ui.icons;
+
+import javax.swing.*;
+import java.awt.*;
+
+public final class ChevronDownIcon implements Icon {
+    private final int w, h;
+
+    public ChevronDownIcon(int w, int h) { this.w = w; this.h = h; }
+
+    @Override public int getIconWidth() { return w; }
+    @Override public int getIconHeight() { return h; }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+        Graphics2D g2 = (Graphics2D) g.create();
+        g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2.setStroke(new BasicStroke(Math.max(1f, w / 10f), BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+
+        int pad = Math.max(1, w / 6);
+        int x1 = x + pad, x2 = x + w - pad;
+        int cy = y + h / 2;
+        int mid = (x1 + x2) / 2;
+
+        g2.setColor(new Color(60, 60, 60));
+        g2.drawLine(x1, cy - 2, mid, cy + 2);
+        g2.drawLine(mid, cy + 2, x2, cy - 2);
+        g2.dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- replace language combo box with compact flag button + popup
- add customizable sizing in UiKnobs and new chevron icon
- keep top bar compact with right-aligned language button

## Testing
- `make ci` *(fails: No rule to make target 'ci')*
- `make build-codex`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea9c7f688324884302d2a02a7e1d