### PR TITLE
Persist language selection with config store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ target/
 logs/
 .idea/
 .DS_Store
-dependency-check-report.
+dependency-check-report
+config.properties

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,65 @@
 ## Local macOS packaging
 - `mvn -P mac-installer -DskipTests package` produces a DMG via jpackage.
 
+## JDK
+- Target: Java 21 (Temurin).
+- No JPMS modules; plain classpath build.
+- Build tool: Maven 3.9+.
+
 ## Dependencies
 - Install local API client from `lib/openapi-java-client-0.0.4.jar` using the sidecar POM:
   `make install-client`
 
 ## Architecture
 This is a Java Swing desktop application for managing a flea market cash register system.
-- Uses OpenAPI client to communicate with iLoppis service
-- Requires Java 21+ with preview features enabled
-- GUI components will fail in headless environments (Codex/CI)
+- Uses OpenAPI client to communicate with iLoppis service.
+- GUI is written in Swing only (no JavaFX).
+- Requires Java 21.
+- GUI components will fail in headless environments (Codex/CI).
+
+## UI Rules
+- UI: Swing only (no JavaFX).
+- Package: all UI code lives under `se.goencoder.loppiskassan.ui`.
+- Always include `import` statements (full FQCNs).
+- Follow existing style: one `JPanel` per view component.
+- High-DPI friendly rendering (use `RenderingHints` for quality scaling).
+- Cashier flow must stay intact:
+  1. Cursor starts in seller number field.
+  2. Tab or Enter moves to price field.
+  3. Enter submits prices and resets fields.
+  4. Cursor returns to seller number field.
+
+## Configuration
+- Persist UI language and other settings using `ConfigurationStore`.
+- Use: `ConfigurationStore.UI_LANGUAGE_STR.getOrDefault("sv")` as the single source of truth.
+- Always update both memory and `config.properties` on change.
+
+## Internationalization
+- All UI text must come from `LocalizationManager.tr("key")`.
+- Keys live under `src/main/resources/lang/{sv,en}.json`.
+- Do not hardcode text in Swing components.
+- Language selector must:
+  - Show flags and labels.
+  - Persist selected language.
+  - Update UI immediately on change.
 
 ## Environment Detection
 The Makefile automatically detects Codex vs local environment:
-- Codex: Uses proxy settings, skips GUI operations
-- Local: Direct connections, full functionality including DMG packaging on macOS
+- CI/Codex: Never try to run Swing UI (`make ci` runs headless).
+- Local macOS: DMG packaging is allowed (`-P mac-installer`).
+- Never call `jpackage` in Codex/CI.
+
+## Codex Prompt Scaffold
+When generating code:
+- Language: Java 21, Swing UI.
+- Project: iLoppis Cash Register desktop app.
+- Constraints:
+  - Must compile with `mvn verify`.
+  - No new external dependencies unless explicitly requested.
+  - Persist settings via `ConfigurationStore`.
+  - Use `LocalizationManager.tr` for text.
+  - Keep cashier keystroke flow intact.
+- Deliverables:
+  1. Exact diffs with file paths under `src/main/java` or `src/main/resources`.
+  2. Full `import` statements.
+  3. Assume Maven project structure.

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,12 @@
             <artifactId>flatlaf-extras</artifactId>
             <version>3.4.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -70,6 +76,14 @@
                 <configuration>
                     <source>21</source>
                     <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/se/goencoder/loppiskassan/config/ConfigurationStore.java
+++ b/src/main/java/se/goencoder/loppiskassan/config/ConfigurationStore.java
@@ -21,7 +21,8 @@ public enum ConfigurationStore {
     API_KEY_STR("api_key"),
     APPROVED_SELLERS_JSON("approved_sellers"),
     OFFLINE_EVENT_BOOL("offline_event"),
-    REVENUE_SPLIT_JSON("revenue_split");
+    REVENUE_SPLIT_JSON("revenue_split"),
+    LANGUAGE_STR("language");
 
     public static final String CONFIG_FILE_PATH = "config.properties";
     private final String key;

--- a/src/main/java/se/goencoder/loppiskassan/localization/LocalizationManager.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/LocalizationManager.java
@@ -1,5 +1,7 @@
 package se.goencoder.loppiskassan.localization;
 
+import se.goencoder.loppiskassan.config.ConfigurationStore;
+
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,7 +11,7 @@ import java.util.List;
  * to retrieve translations. The default language is Swedish.
  */
 public final class LocalizationManager {
-    private static LocalizationStrategy strategy = new JsonLocalizationStrategy("sv");
+    private static LocalizationStrategy strategy = new JsonLocalizationStrategy(languageFromConfig());
 
     /** Listener for language change events. */
     public interface LanguageChangeListener { void onLanguageChanged(); }
@@ -28,10 +30,19 @@ public final class LocalizationManager {
      * @param languageCode ISO language code (e.g. "sv", "en")
      */
     public static void setLanguage(String languageCode) {
+        ConfigurationStore.LANGUAGE_STR.set(languageCode);
         strategy = new JsonLocalizationStrategy(languageCode);
         for (LanguageChangeListener l : new ArrayList<>(listeners)) {
             l.onLanguageChanged();
         }
+    }
+
+    public static String getLanguage() {
+        return languageFromConfig();
+    }
+
+    public static void reloadFromConfig() {
+        strategy = new JsonLocalizationStrategy(languageFromConfig());
     }
 
     /**
@@ -41,5 +52,10 @@ public final class LocalizationManager {
     public static String tr(String key, Object... args) {
         String value = strategy.get(key);
         return args.length > 0 ? MessageFormat.format(value, args) : value;
+    }
+
+    private static String languageFromConfig() {
+        String value = ConfigurationStore.LANGUAGE_STR.get();
+        return value != null ? value : "sv";
     }
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/LanguageSelector.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/LanguageSelector.java
@@ -111,9 +111,25 @@ public final class LanguageSelector extends JPanel {
     }
 
     private static String currentLanguage() {
-        // If you persist language elsewhere, hook it here.
-        // Default to "sv" to match existing behavior.
-        return "sv";
+        return LocalizationManager.getLanguage();
+    }
+
+    public void selectLanguage(String code) {
+        if (code == null) {
+            return;
+        }
+        if (!code.equals(currentLanguage())) {
+            LocalizationManager.setLanguage(code);
+            updateTriggerForCurrentLanguage();
+        }
+    }
+
+    public String getSelectedLanguageCode() {
+        return currentLanguage();
+    }
+
+    public String getTriggerTooltip() {
+        return trigger.getToolTipText();
     }
 
     // Helper to paint two icons side-by-side (flag + chevron)

--- a/src/test/java/se/goencoder/loppiskassan/ui/LanguageSelectorTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/ui/LanguageSelectorTest.java
@@ -1,0 +1,43 @@
+package se.goencoder.loppiskassan.ui;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import se.goencoder.loppiskassan.config.ConfigurationStore;
+import se.goencoder.loppiskassan.localization.LocalizationManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LanguageSelectorTest {
+
+    @BeforeAll
+    static void headless() {
+        System.setProperty("java.awt.headless", "true");
+    }
+
+    @BeforeEach
+    void resetConfig() {
+        ConfigurationStore.reset();
+        LocalizationManager.reloadFromConfig();
+    }
+
+    @Test
+    void selectingLanguagePersistsInConfig() {
+        LanguageSelector selector = new LanguageSelector();
+        assertEquals("sv", selector.getSelectedLanguageCode());
+
+        selector.selectLanguage("en");
+        assertEquals("en", selector.getSelectedLanguageCode());
+        assertEquals("en", ConfigurationStore.LANGUAGE_STR.get());
+    }
+
+    @Test
+    void usesPersistedLanguageOnInit() {
+        ConfigurationStore.LANGUAGE_STR.set("en");
+        LocalizationManager.reloadFromConfig();
+
+        LanguageSelector selector = new LanguageSelector();
+        assertEquals("en", selector.getSelectedLanguageCode());
+        assertEquals("English", selector.getTriggerTooltip());
+    }
+}


### PR DESCRIPTION
## Summary
- persist chosen language in `ConfigurationStore` and expose accessors in `LocalizationManager`
- update `LanguageSelector` to use and modify persisted language
- add JUnit and tests asserting language selection is stored and restored

## Testing
- `make build-codex`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a5f4b4cba883249b70c826e2578287