### PR TITLE
Center SelectMarketDialog controls and add version footer

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/config/ConfigurationStore.java
+++ b/src/main/java/se/goencoder/loppiskassan/config/ConfigurationStore.java
@@ -22,7 +22,8 @@ public enum ConfigurationStore {
     APPROVED_SELLERS_JSON("approved_sellers"),
     OFFLINE_EVENT_BOOL("offline_event"),
     REVENUE_SPLIT_JSON("revenue_split"),
-    LANGUAGE_STR("language");
+    LANGUAGE_STR("language"),
+    APP_VERSION_STR("app_version");
 
     public static final String CONFIG_FILE_PATH = "config.properties";
     private final String key;

--- a/src/main/java/se/goencoder/loppiskassan/ui/SelectMarketDialog.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/SelectMarketDialog.java
@@ -1,0 +1,92 @@
+package se.goencoder.loppiskassan.ui;
+
+import se.goencoder.loppiskassan.config.ConfigurationStore;
+import se.goencoder.loppiskassan.localization.LocalizationManager;
+
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+
+/**
+ * Dialog for selecting a market when multiple markets are available.
+ * The main controls are centered vertically for a balanced appearance.
+ */
+public class SelectMarketDialog extends JDialog {
+    private final JComboBox<String> marketComboBox;
+
+    public SelectMarketDialog(Frame owner) {
+        super(owner, LocalizationManager.tr("select_market.title"), true);
+        setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+        getContentPane().setLayout(new BorderLayout());
+
+        JPanel centerPanel = new JPanel();
+        centerPanel.setLayout(new BoxLayout(centerPanel, BoxLayout.Y_AXIS));
+        centerPanel.setBorder(new EmptyBorder(10, 10, 10, 10));
+        centerPanel.add(Box.createVerticalGlue());
+
+        JLabel promptLabel = new JLabel(LocalizationManager.tr("select_market.label"));
+        promptLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+        centerPanel.add(promptLabel);
+        centerPanel.add(Box.createVerticalStrut(8));
+
+        marketComboBox = new JComboBox<>();
+        marketComboBox.setAlignmentX(Component.CENTER_ALIGNMENT);
+        centerPanel.add(marketComboBox);
+        centerPanel.add(Box.createVerticalStrut(12));
+
+        JPanel buttonPanel = new JPanel();
+        JButton okButton = new JButton(LocalizationManager.tr("popup.confirm"));
+        JButton cancelButton = new JButton(LocalizationManager.tr("popup.cancel"));
+        buttonPanel.add(okButton);
+        buttonPanel.add(cancelButton);
+        centerPanel.add(buttonPanel);
+        centerPanel.add(Box.createVerticalGlue());
+
+        getContentPane().add(centerPanel, BorderLayout.CENTER);
+
+        JLabel versionLabel = new JLabel(ConfigurationStore.APP_VERSION_STR.get());
+        JPanel footerPanel = new JPanel(new BorderLayout());
+        footerPanel.setBorder(new EmptyBorder(0, 0, 5, 5));
+        footerPanel.add(versionLabel, BorderLayout.EAST);
+        getContentPane().add(footerPanel, BorderLayout.SOUTH);
+
+        pack();
+        setLocationRelativeTo(owner);
+
+        cancelButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        });
+        okButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                dispose();
+            }
+        });
+    }
+
+    public void setMarkets(String[] markets) {
+        marketComboBox.removeAllItems();
+        if (markets != null) {
+            for (String market : markets) {
+                marketComboBox.addItem(market);
+            }
+        }
+    }
+
+    public String getSelectedMarket() {
+        return (String) marketComboBox.getSelectedItem();
+    }
+}

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -10,6 +10,8 @@
   "error.no_event_selected.title": "No event selected",
   "error.no_event_selected.message": "Please select an event before opening a cash register.",
   "frame.title": "iLoppis Cash Register v1.0",
+  "select_market.title": "Select Market",
+  "select_market.label": "Select market:",
   "popup.confirm": "Confirm",
   "popup.cancel": "Cancel",
   "error.create_dirs.title": "Could not create directories",

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -10,6 +10,8 @@
   "error.no_event_selected.title": "Ingen loppis vald",
   "error.no_event_selected.message": "Vänligen välj en loppis att öppna en kassa för först.",
   "frame.title": "iLoppis Kassahantering v1.0",
+  "select_market.title": "Välj Loppis",
+  "select_market.label": "Välj loppis:",
   "popup.confirm": "Bekräfta",
   "popup.cancel": "Avbryt",
   "error.create_dirs.title": "Kunde inte skapa kataloger",


### PR DESCRIPTION
## Summary
- Add APP_VERSION_STR to ConfigurationStore and provide translations for the Select Market dialog
- Introduce SelectMarketDialog using vertical centering and include app version footer

## Testing
- `make build-codex`
- `mvn test`
- `mvn verify`
- `make ci` *(fails: No rule to make target 'ci')*

------
https://chatgpt.com/codex/tasks/task_e_68a5fb62216c8324a79619ae3f32bd96