### PR TITLE
Require cashier code for online events

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
@@ -146,7 +146,16 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         discoverButton.addActionListener(e -> controller.discoverEvents(dateFromField.getText().trim()));
         getTokenButton.addActionListener(e -> {
             int rowIndex = getSelectedTableRow();
-            controller.openRegister(getEventIdForRow(rowIndex), getCashierCode());
+            String eventId = getEventIdForRow(rowIndex);
+            String cashierCode = getCashierCode();
+            boolean isOffline = "offline".equalsIgnoreCase(eventId);
+            if (!isOffline && cashierCode.isEmpty()) {
+                Popup.ERROR.showAndWait(
+                        LocalizationManager.tr("error.title"),
+                        LocalizationManager.tr("error.cashier_code_required"));
+                return;
+            }
+            controller.openRegister(eventId, cashierCode);
         });
 
         return panel;

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -112,6 +112,8 @@
   "info.register_ready.message": "The register is ready to use.",
   "error.fetch_token.title": "Could not fetch token",
   "error.fetch_token.message": "Incorrect cashier code? {0}",
+  "error.cashier_code_required": "Cashier code is required for online events.",
+  "error.title": "Error",
   "confirm.change_event.title": "Change event?",
   "confirm.change_event.message": "All local records will be erased.\nIf offline they are lost forever.\nIf online, any unsynced entries are lost.\n\nContinue?",
   "error.clear_register_file": "Error clearing register file: {0}",

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -112,6 +112,8 @@
   "info.register_ready.message": "Kassan är redo att användas.",
   "error.fetch_token.title": "Kunde inte hämta token",
   "error.fetch_token.message": "Felaktig kassakod? {0}",
+  "error.cashier_code_required": "Kassakod krävs för online-loppisar.",
+  "error.title": "Fel",
   "confirm.change_event.title": "Byt event?",
   "confirm.change_event.message": "Alla dina lokala registerposter kommer att raderas.\nOm du är offline går de förlorade för alltid.\nOm du är online går ej uppladdade poster förlorade.\n\nVill du fortsätta?",
   "error.clear_register_file": "Fel vid rensning av kassafil: {0}",


### PR DESCRIPTION
## Summary
- validate cashier code before opening register for online events, showing a localized error
- add English and Swedish translations for the new error message and title

## Testing
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a5ffa5336c8324bcb5bd5b507f636b