### PR TITLE
docs: add Javadocs to interfaces

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/controller/CashierControllerInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/controller/CashierControllerInterface.java
@@ -1,22 +1,74 @@
 package se.goencoder.loppiskassan.controller;
 
-
 import se.goencoder.loppiskassan.ui.CashierPanelInterface;
 
 import javax.swing.*;
 
+/**
+ * Controller contract for cashier interactions.
+ * <p>
+ * Mode behavior:
+ * <ul>
+ *   <li><b>Online:</b> may validate sellers against the server and offer Swish checkout.</li>
+ *   <li><b>Offline:</b> should skip remote validations and disable Swish, allowing cash-only flow.</li>
+ * </ul>
+ */
 public interface CashierControllerInterface {
+
+    /**
+     * Wire the cash checkout action to the provided button.
+     * @param checkoutCashButton Swing button to receive the action
+     */
     void setupCheckoutCashButtonAction(JButton checkoutCashButton);
+
+    /**
+     * Wire the Swish checkout action to the provided button.
+     * Implementations should disable or no-op this action in offline mode.
+     *
+     * @param checkoutSwishButton Swing button to receive the action
+     */
     void setupCheckoutSwishButtonAction(JButton checkoutSwishButton);
+
+    /**
+     * Wire the cancel checkout action to the provided button.
+     * @param cancelCheckoutButton Swing button to receive the action
+     */
     void setupCancelCheckoutButtonAction(JButton cancelCheckoutButton);
 
+    /**
+     * Attach input handling to the prices text field (e.g., Enter to add item, validation).
+     * @param pricesTextField the text field with price input
+     */
     void setupPricesTextFieldAction(JTextField pricesTextField);
 
+    /**
+     * Register the view so the controller can push updates and read user inputs.
+     * @param view cashier panel view
+     */
     void registerView(CashierPanelInterface view);
 
+    /**
+     * Delete a previously added item by its identifier.
+     * Mode-independent, but errors/ confirmations may differ by mode.
+     *
+     * @param itemId unique identifier of the item to remove
+     */
     void deleteItem(String itemId);
 
+    /**
+     * Compute change to give for a cash payment based on current total.
+     * @param payedAmount amount tendered by the customer (whole units)
+     */
     void calculateChange(int payedAmount);
 
+    /**
+     * Determine whether a seller is approved to sell.
+     * <p>
+     * <b>Online:</b> typically verified via server lookup.
+     * <b>Offline:</b> rely on locally cached state or default to permissive rules.
+     *
+     * @param sellerId numeric seller identifier
+     * @return {@code true} if approved, otherwise {@code false}
+     */
     boolean isSellerApproved(int sellerId);
 }

--- a/src/main/java/se/goencoder/loppiskassan/controller/DiscoveryControllerInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/controller/DiscoveryControllerInterface.java
@@ -2,46 +2,59 @@ package se.goencoder.loppiskassan.controller;
 
 import se.goencoder.loppiskassan.ui.DiscoveryPanelInterface;
 
-
-
+/**
+ * Controller contract for discovering events and opening the register.
+ * <p>
+ * Mode behavior:
+ * <ul>
+ *   <li><b>Online:</b> fetch events from the backend; opening the register requires a valid cashier code.</li>
+ *   <li><b>Offline:</b> list locally configured events; opening the register ignores cashier code and uses offline defaults.</li>
+ * </ul>
+ */
 public interface DiscoveryControllerInterface {
 
     /**
-     * Register a view with the controller.
-     * @param view The view to register
+     * Register the associated view.
+     * @param view discovery panel view
      */
     void registerView(DiscoveryPanelInterface view);
 
     /**
-     * Called when the user clicks "Upptäck event".
-     * @param dateFrom
+     * Discover events visible to the user starting from an optional date.
+     * Online mode should query the backend; offline mode should read local storage.
+     *
+     * @param dateFrom ISO-8601 date string (inclusive) or empty for all
      */
     void discoverEvents(String dateFrom);
 
     /**
-     * Called when the user clicks "Hämta API-nyckel".
-     * @param eventId
-     * @param cashierCode
+     * Open the register for a selected event.
+     * <p>
+     * <b>Online:</b> {@code cashierCode} must be present and validated.
+     * <b>Offline:</b> {@code cashierCode} may be ignored and the register opens immediately.
+     *
+     * @param eventId unique event identifier
+     * @param cashierCode cashier/ API code (required online)
      */
     void openRegister(String eventId, String cashierCode);
 
-
     /**
-     * Called when the user selects an event from the table (by row).
-     * The eventId might be "offline" (synthetic) or a real ID from the API.
+     * Notify that the user selected a new event in the UI.
+     * Controller should update detail fields and validation state.
+     *
+     * @param eventId selected event identifier
      */
     void eventSelected(String eventId);
 
-
     /**
-     * Init UI state
+     * Initialize the discovery view to a consistent default state
+     * (clear tables, hide details, set mode, etc.).
      */
     void initUIState();
 
     /**
-     * Called when the user clicks "Ändra event".
+     * Handle the user request to change the currently active event.
+     * Typically returns the UI to the discovery list and resets register state.
      */
     void changeEventRequested();
-
-
 }

--- a/src/main/java/se/goencoder/loppiskassan/controller/HistoryControllerInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/controller/HistoryControllerInterface.java
@@ -2,11 +2,38 @@ package se.goencoder.loppiskassan.controller;
 
 import se.goencoder.loppiskassan.ui.HistoryPanelInterface;
 
-
+/**
+ * Controller contract for the history screen.
+ * <p>
+ * Mode behavior:
+ * <ul>
+ *   <li><b>Online:</b> may load/refresh from the backend and support server-side filtering.</li>
+ *   <li><b>Offline:</b> loads from local session data or cached storage only.</li>
+ * </ul>
+ */
 public interface HistoryControllerInterface {
+
+    /**
+     * Register the history view so the controller can push data and read filters.
+     * @param view history panel view
+     */
     void registerView(HistoryPanelInterface view);
+
+    /**
+     * Load or refresh the current history data set, obeying active filters.
+     * Online mode may call the backend; offline mode should read local data.
+     */
     void loadHistory();
+
+    /**
+     * Notify the controller that one or more filters changed and data should be re-evaluated.
+     * Implementations should debounce as needed.
+     */
     void filterUpdated();
-    // New method for direct button action handling
+
+    /**
+     * Handle a button action exposed by the history view (e.g., "import", "export").
+     * @param actionCommand logical action command string from the view
+     */
     void buttonAction(String actionCommand);
 }

--- a/src/main/java/se/goencoder/loppiskassan/localization/LocalizationAware.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/LocalizationAware.java
@@ -1,11 +1,14 @@
 package se.goencoder.loppiskassan.localization;
 
 /**
- * Components that need to update their displayed texts when the language
- * changes should implement this interface.
+ * Marker for views/controllers that need to react when the UI language changes.
  */
 public interface LocalizationAware {
-    /** Reload all user-facing texts from the {@link LocalizationManager}. */
+
+    /**
+     * Reload all user-visible texts from the active {@link se.goencoder.loppiskassan.localization.LocalizationManager}.
+     * Implementations should update labels, tooltips, table headers, and any cached texts.
+     */
     void reloadTexts();
 }
 

--- a/src/main/java/se/goencoder/loppiskassan/localization/LocalizationStrategy.java
+++ b/src/main/java/se/goencoder/loppiskassan/localization/LocalizationStrategy.java
@@ -1,14 +1,18 @@
 package se.goencoder.loppiskassan.localization;
 
 /**
- * Strategy interface for providing translations.
+ * Lookup strategy for localized strings.
  */
 public interface LocalizationStrategy {
+
     /**
-     * Returns the translation for the given key.
+     * Return a localized message for the given i18n key.
+     * <p>
+     * Implementations should fall back to the key itself if the translation is missing,
+     * and may support parameter interpolation depending on the backing store.
      *
-     * @param key translation key
-     * @return translated string or the key itself if missing
+     * @param key i18n message key (e.g., "cashier.open")
+     * @return localized string, or the key if not found
      */
     String get(String key);
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/CashierPanelInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/CashierPanelInterface.java
@@ -4,21 +4,79 @@ import se.goencoder.loppiskassan.SoldItem;
 
 import java.util.Map;
 
-public interface CashierPanelInterface extends SelectabableTab, UiComponent{
+/**
+ * View contract for the Cashier screen.
+ * <p>
+ * Mode awareness:
+ * <ul>
+ *   <li><b>Online:</b> UI may show network-related states (seller approval fetched, Swish enabled).</li>
+ *   <li><b>Offline:</b> UI should guide the user to cash-only flow and surface limited validation.</li>
+ * </ul>
+ */
+public interface CashierPanelInterface extends SelectabableTab, UiComponent {
+
+    /**
+     * Move focus to the seller input field.
+     * Use when the view is shown or after clearing state.
+     */
     void setFocusToSellerField();
+
+    /**
+     * Enable/disable checkout action buttons (cash/Swish) based on current state
+     * such as items present, seller approval, or mode limitations.
+     *
+     * @param enable {@code true} to enable, {@code false} to disable
+     */
     void enableCheckoutButtons(boolean enable);
+
+    /**
+     * Append a sold item to the running list in the UI.
+     * Implementations should update totals and relevant counters.
+     *
+     * @param item the item that was sold
+     */
     void addSoldItem(SoldItem item);
+
+    /**
+     * Update the sum label with a formatted total (e.g., "Summa: 123 kr").
+     *
+     * @param newText formatted total text
+     */
     void updateSumLabel(String newText);
+
+    /**
+     * Update the UI text for the count of items (e.g., "0 varor").
+     *
+     * @param newText localized/ formatted text
+     */
     void updateNoItemsLabel(String newText);
 
+    /**
+     * Update the entered cash amount used for change calculation.
+     *
+     * @param amount amount in whole currency units (e.g., SEK)
+     */
     void updatePayedCashField(Integer amount);
 
+    /**
+     * Update the calculated change-to-give field.
+     *
+     * @param amount change amount in whole currency units
+     */
     void updateChangeCashField(Integer amount);
 
     /**
-     * Hämtar och rensar säljare och priser från vyn.
-     * @return Map med säljare och priser.
+     * Retrieve and clear the seller→prices mapping from the UI in a single, atomic operation.
+     * Implementations should also reset the input fields to prepare for the next transaction.
+     *
+     * @return map keyed by seller id; each value is a two-element array
+     *         {@code [priceForVendor, priceForMarketOwner]}
      */
     Map<Integer, Integer[]> getAndClearSellerPrices();
+
+    /**
+     * Clear all input fields, tables, and derived labels.
+     * Typically used after a successful checkout or when switching events/mode.
+     */
     void clearView();
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryPanelInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryPanelInterface.java
@@ -6,83 +6,104 @@ import se.goencoder.iloppis.model.RevenueSplit;
 import java.util.List;
 
 /**
- * Panel interface for the "Discovery"/"Konfiguration" tab.
+ * View contract for discovering and selecting events (loppisar) and opening the register.
+ * <p>
+ * Mode awareness:
+ * <ul>
+ *   <li><b>Online:</b> shows remote events and requires a valid cashier code to open the register.</li>
+ *   <li><b>Offline:</b> shows locally configured events and should gate features accordingly.</li>
+ * </ul>
  */
 public interface DiscoveryPanelInterface extends SelectabableTab {
-    /**
-     * Clears the events table.
-     */
+
+    /** Clear the events table. */
     void clearEventsTable();
 
     /**
-     * Populates the events table with the given list of events.
-     * @param events
+     * Populate the events table with discovered events.
+     * @param events events to display (may be empty)
      */
     void populateEventsTable(List<Event> events);
 
-
-
     /**
-     * Sets the name of the event in the UI.
+     * Set the selected event name in the detail section.
+     * @param name event name
      */
     void setEventName(String name);
 
     /**
-     * Sets the description of the event in the UI.
+     * Set the selected event description in the detail section.
+     * @param description free-text description
      */
     void setEventDescription(String description);
 
     /**
-     * Sets the address of the event in the UI.
+     * Set the selected event address (single-line display string).
+     * @param address formatted address
      */
     void setEventAddress(String address);
 
     /**
-     * Sets whether the "offline" event is currently selected or not.
+     * Indicate whether the UI is in offline mode.
+     * Implementations should hide/disable online-only controls (e.g., API key/ cashier code).
+     *
+     * @param offline {@code true} for offline mode, {@code false} for online
      */
     void setOfflineMode(boolean offline);
 
     /**
-     * Enable/disable the manual edit of revenue splits (only allowed if offline).
+     * Enable/disable editing of revenue split percentages.
+     * Typically editable offline; read-only when sourced from the server online.
+     *
+     * @param editable {@code true} to allow editing
      */
     void setRevenueSplitEditable(boolean editable);
 
     /**
-     * Sets each part of the revenue split in the UI.
+     * Update the displayed revenue split for market owner/ vendor/ platform.
+     *
+     * @param marketOwner percentage for the market owner (0–100)
+     * @param vendor percentage for the vendor (0–100)
+     * @param platform percentage for the platform (0–100)
      */
     void setRevenueSplit(float marketOwner, float vendor, float platform);
 
-
     /**
-     * Enables/disables the "Öppna Kassa" button.
+     * Enable/disable the "Open Register" button depending on validation state
+     * (e.g., event selected + valid cashier code in online mode).
+     *
+     * @param enabled {@code true} to enable, {@code false} to disable
      */
     void setCashierButtonEnabled(boolean enabled);
 
     /**
-     * Clears the cashier code field.
+     * Clear the cashier code input field.
+     * Typically used after successfully opening the register or when changing event.
      */
     void clearCashierCodeField();
 
-    // Switch between "noSelection" label and the detail form card
+    /**
+     * Show or hide the event details form area.
+     * @param show {@code true} to show, {@code false} to hide
+     */
     void showDetailForm(boolean show);
 
-
     /**
-     * Switches the UI to "active event" mode if true,
-     * or back to "normal selection" mode if false.
+     * Reflect whether the register is currently open for the active event.
+     * @param opened {@code true} if open, otherwise {@code false}
      */
     void setRegisterOpened(boolean opened);
 
     /**
-     * Displays basic info about the active event in the UI,
-     * e.g. name, address, etc.
+     * Display basic information about the active event and its revenue split.
+     * @param event the active event
+     * @param split the associated revenue split
      */
     void showActiveEventInfo(Event event, RevenueSplit split);
 
     /**
-     * Called by the controller to show/hide the "Change event" button.
+     * Show or hide the "Change event" button allowing the user to pick a different event.
+     * @param visible {@code true} to show, {@code false} to hide
      */
     void setChangeEventButtonVisible(boolean visible);
-
-
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/HistoryPanelInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/HistoryPanelInterface.java
@@ -5,18 +5,74 @@ import se.goencoder.loppiskassan.SoldItem;
 import java.util.List;
 import java.util.Set;
 
-public interface HistoryPanelInterface extends SelectabableTab, UiComponent{
+/**
+ * View contract for the Sales History screen.
+ * <p>
+ * Mode awareness:
+ * <ul>
+ *   <li><b>Online:</b> history may include server-side entries and support import/refresh.</li>
+ *   <li><b>Offline:</b> history is limited to locally captured sales during the session or local storage.</li>
+ * </ul>
+ */
+public interface HistoryPanelInterface extends SelectabableTab, UiComponent {
+
+    /**
+     * Replace the table contents with the supplied sales items.
+     * Implementations should preserve current filters if applicable.
+     *
+     * @param items sales items to display
+     */
     void updateHistoryTable(List<SoldItem> items);
+
+    /**
+     * Update the formatted sum display shown in the history view.
+     *
+     * @param sum localized/ formatted total text (e.g., "1 234 kr")
+     */
     void updateSumLabel(String sum);
+
+    /**
+     * Update the text reflecting the number of items.
+     *
+     * @param noItems localized text (e.g., "0 varor")
+     */
     void updateNoItemsLabel(String noItems);
+
+    /**
+     * @return current seller filter value (empty if no filter)
+     */
     String getSellerFilter();
+
+    /**
+     * @return current payment method filter (e.g., "CASH", "SWISH", or empty)
+     */
     String getPaymentMethodFilter();
 
+    /**
+     * @return current paid-state filter (e.g., "PAID", "UNPAID", or empty)
+     */
     String getPaidFilter();
+
+    /**
+     * Replace the seller dropdown contents with the provided set.
+     *
+     * @param sellers distinct seller labels to show
+     */
     void updateSellerDropdown(Set<String> sellers);
+
+    /**
+     * Enable/disable a named button in the view (e.g., "import", "export").
+     *
+     * @param buttonName logical name of the button
+     * @param enable {@code true} to enable, {@code false} to disable
+     */
     void enableButton(String buttonName, boolean enable);
+
+    /**
+     * Update the import button caption to reflect the current action/ mode
+     * (e.g., "Importera" vs "Synka" when online).
+     *
+     * @param text localized button text
+     */
     void setImportButtonText(String text);
-
-
-
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/SelectabableTab.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/SelectabableTab.java
@@ -1,6 +1,13 @@
 package se.goencoder.loppiskassan.ui;
 
+/**
+ * Contract for tabs that want a callback when they become active/selected.
+ */
 public interface SelectabableTab {
 
+    /**
+     * Called by the tab container when this tab becomes the active selection.
+     * Implementations typically refresh data, focus a default input, or update UI state.
+     */
     void selected();
 }

--- a/src/main/java/se/goencoder/loppiskassan/ui/UiComponent.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/UiComponent.java
@@ -2,11 +2,18 @@ package se.goencoder.loppiskassan.ui;
 
 import java.awt.*;
 
+/**
+ * Common contract for Swing-based panels that expose a root {@link java.awt.Component}.
+ */
 public interface UiComponent {
+
     /**
-     * Returns the root component of this panel for use with dialogs and spinners.
+     * Return the root Swing component for this view.
+     * <p>
+     * This is typically the panel returned to container layouts (tabs, dialogs, etc.).
+     * Implementations should return the same instance consistently.
      *
-     * @return The root component of this panel.
+     * @return the root {@link java.awt.Component} of this panel
      */
     Component getComponent();
 }


### PR DESCRIPTION
## Summary
- document shared UI contract `UiComponent` and tab selection callback `SelectabableTab`
- add mode-aware docs for cashier, history, and discovery panels & controllers
- describe localization responsibilities

## Testing
- `make build-codex`
- `mvn test`
- `mvn verify`


------
https://chatgpt.com/codex/tasks/task_e_68a6c291c7708324a2fad43f3b962050