### PR TITLE
Centralize number parsing and formatting

### DIFF
--- a/src/main/java/se/goencoder/loppiskassan/ui/CashierPanelInterface.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/CashierPanelInterface.java
@@ -38,32 +38,18 @@ public interface CashierPanelInterface extends SelectabableTab, UiComponent {
     void addSoldItem(SoldItem item);
 
     /**
-     * Update the sum label with a formatted total (e.g., "Summa: 123 kr").
-     *
-     * @param newText formatted total text
-     */
-    void updateSumLabel(String newText);
-
-    /**
-     * Update the UI text for the count of items (e.g., "0 varor").
-     *
-     * @param newText localized/ formatted text
-     */
-    void updateNoItemsLabel(String newText);
-
-    /**
      * Update the entered cash amount used for change calculation.
      *
      * @param amount amount in whole currency units (e.g., SEK)
      */
-    void updatePayedCashField(Integer amount);
+    void setPaidAmount(int amount);
 
     /**
      * Update the calculated change-to-give field.
      *
      * @param amount change amount in whole currency units
      */
-    void updateChangeCashField(Integer amount);
+    void setChange(int amount);
 
     /**
      * Retrieve and clear the seller→prices mapping from the UI in a single, atomic operation.

--- a/src/main/java/se/goencoder/loppiskassan/ui/CashierTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/CashierTabPanel.java
@@ -6,14 +6,15 @@ import se.goencoder.loppiskassan.localization.LocalizationManager;
 import se.goencoder.loppiskassan.localization.LocalizationAware;
 
 import javax.swing.*;
-import javax.swing.table.DefaultTableModel;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import se.goencoder.loppiskassan.util.Money;
+import se.goencoder.loppiskassan.util.PriceList;
 
 import static se.goencoder.loppiskassan.ui.UserInterface.createButton;
 
@@ -25,10 +26,9 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
 
     // Components for the cashier table and input fields
     private JTable cashierTable;
-    private JTextField sellerField, pricesField, payedCashField, changeCashField;
+    private JTextField sellerField, pricesField, payedCashField;
     private JLabel noItemsLabel, sumLabel;
     private JLabel sellerLabel, pricesLabel, paidLabel, changeLabel;
-    // New: visible label for change, while keeping the hidden text field for controller updates
     private JLabel changeValueLabel;
 
     // Buttons for checkout actions
@@ -78,16 +78,13 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
                 LocalizationManager.tr("cashier.table.price"),
                 LocalizationManager.tr("cashier.table.item_id")
         };
-        DefaultTableModel tableModel = new DefaultTableModel(null, columnNames) {
-            @Override
-            public boolean isCellEditable(int row, int column) {
-                return false; // Prevent cell editing
-            }
-        };
+        SoldItemsTableModel tableModel = new SoldItemsTableModel(columnNames);
         cashierTable = new JTable(tableModel);
-        cashierTable.removeColumn(cashierTable.getColumnModel().getColumn(2)); // Hide "Item ID" column
+        cashierTable.getColumnModel().getColumn(1).setCellRenderer(Renderers.rightAligned());
+        cashierTable.removeColumn(cashierTable.getColumnModel().getColumn(2));
 
-        // Add a key listener for delete functionality
+        tableModel.addTableModelListener(e -> updateSummary());
+
         cashierTable.addKeyListener(new KeyAdapter() {
             @Override
             public void keyPressed(KeyEvent e) {
@@ -95,7 +92,7 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
                     int row = cashierTable.getSelectedRow();
                     if (row >= 0) {
                         String itemId = tableModel.getValueAt(row, 2).toString();
-                        controller.deleteItem(itemId); // Delete the item from the table
+                        controller.deleteItem(itemId);
                     }
                 }
             }
@@ -116,9 +113,8 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
         // --- init fields ---
         sellerField = new JTextField();
         pricesField = new JTextField();
-        payedCashField = new JTextField();      // stays editable
-        changeCashField = new JTextField();     // kept for controller; will be hidden and mirrored to a JLabel
-        changeCashField.setEditable(false);
+        payedCashField = new JTextField();
+        changeValueLabel = new JLabel();
 
         // Keep the fields clean as the user types (no jumpy caret):
         // - seller: 3 digits max
@@ -169,27 +165,12 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
         infoPanel.add(changeValueLabel);
         inputPanel.add(infoPanel);
 
-        // We keep changeCashField but DON'T add it to the layout.
-        // Mirror its text to the visible changeValueLabel so existing controller code keeps working.
-        changeCashField.getDocument().addDocumentListener(new DocumentListener() {
-            private void sync() { changeValueLabel.setText(changeCashField.getText()); }
-            @Override public void insertUpdate(DocumentEvent e) { sync(); }
-            @Override public void removeUpdate(DocumentEvent e) { sync(); }
-            @Override public void changedUpdate(DocumentEvent e) { sync(); }
-        });
-
         // Add a key listener to calculate change dynamically (no extra sanitizing needed with filters)
         payedCashField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyReleased(KeyEvent e) {
-                try {
-                    int payedAmount = payedCashField.getText().isEmpty() ? 0 : Integer.parseInt(payedCashField.getText());
-                    controller.calculateChange(payedAmount);
-                } catch (NumberFormatException ex) {
-                    Popup.WARNING.showAndWait(
-                            LocalizationManager.tr("cashier.invalid_amount.title"),
-                            LocalizationManager.tr("cashier.invalid_amount.message"));
-                }
+                int payedAmount = payedCashField.getText().isEmpty() ? 0 : Integer.parseInt(payedCashField.getText());
+                controller.calculateChange(payedAmount);
             }
         });
 
@@ -241,8 +222,8 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
         checkoutCashButton.setText(LocalizationManager.tr("cashier.cash"));
         checkoutSwishButton.setText(LocalizationManager.tr("cashier.swish"));
 
-        DefaultTableModel model = (DefaultTableModel) cashierTable.getModel();
-        model.setColumnIdentifiers(new String[]{
+        SoldItemsTableModel model = getTableModel();
+        model.setColumnNames(new String[]{
                 LocalizationManager.tr("cashier.table.seller"),
                 LocalizationManager.tr("cashier.table.price"),
                 LocalizationManager.tr("cashier.table.item_id")
@@ -250,17 +231,29 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
         if (cashierTable.getColumnModel().getColumnCount() > 2) {
             cashierTable.removeColumn(cashierTable.getColumnModel().getColumn(2));
         }
-
-        noItemsLabel.setText(LocalizationManager.tr("cashier.no_items", itemsCount));
-        sumLabel.setText(LocalizationManager.tr("cashier.sum", sumValue));
+        updateSummary();
     }
 
     // ------------------------------------------------------------------------
     // Methods for interacting with the CashierControllerInterface
     // ------------------------------------------------------------------------
 
-    private DefaultTableModel getTableModel() {
-        return (DefaultTableModel) cashierTable.getModel();
+    private SoldItemsTableModel getTableModel() {
+        return (SoldItemsTableModel) cashierTable.getModel();
+    }
+
+    private void updateSummary() {
+        SoldItemsTableModel model = getTableModel();
+        itemsCount = model.getRowCount();
+        int total = 0;
+        for (SoldItem item : model.getItems()) {
+            total += item.getPrice();
+        }
+        sumValue = total;
+        Locale locale = new Locale(LocalizationManager.getLanguage());
+        noItemsLabel.setText(LocalizationManager.tr("cashier.no_items", itemsCount));
+        sumLabel.setText(Money.formatAmount(sumValue, locale, LocalizationManager.tr("currency.sek")));
+        enableCheckoutButtons(itemsCount > 0);
     }
 
     @Override
@@ -277,79 +270,47 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
 
     @Override
     public void addSoldItem(SoldItem item) {
-        DefaultTableModel model = getTableModel();
-        model.insertRow(0, new Object[]{item.getSeller(), item.getPrice(), item.getItemId()});
+        getTableModel().addItem(item);
     }
 
     @Override
-    public void updateSumLabel(String newText) {
-        sumValue = Integer.parseInt(newText);
-        sumLabel.setText(LocalizationManager.tr("cashier.sum", sumValue));
+    public void setPaidAmount(int amount) {
+        payedCashField.setText(String.valueOf(amount));
     }
 
     @Override
-    public void updateNoItemsLabel(String newText) {
-        itemsCount = Integer.parseInt(newText);
-        noItemsLabel.setText(LocalizationManager.tr("cashier.no_items", itemsCount));
-    }
-
-    @Override
-    public void updatePayedCashField(Integer amount) {
-        payedCashField.setText(amount.toString());
-    }
-
-    @Override
-    public void updateChangeCashField(Integer amount) {
-        changeCashField.setText(amount.toString());
+    public void setChange(int amount) {
+        Locale locale = new Locale(LocalizationManager.getLanguage());
+        changeValueLabel.setText(Money.formatAmount(amount, locale, LocalizationManager.tr("currency.sek")));
     }
 
     @Override
     public Map<Integer, Integer[]> getAndClearSellerPrices() {
         String seller = sellerField.getText();
         int sellerId;
-
         try {
             sellerId = Integer.parseInt(seller);
         } catch (NumberFormatException e) {
-            Popup.WARNING.showAndWait(
-                    LocalizationManager.tr("cashier.invalid_seller.title"),
-                    LocalizationManager.tr("cashier.invalid_seller.message"));
+            Popup.warn("cashier.invalid_seller");
             return new HashMap<>();
         }
 
         if (!controller.isSellerApproved(sellerId)) {
-            Popup.WARNING.showAndWait(
-                    LocalizationManager.tr("cashier.seller_not_approved.title"),
-                    LocalizationManager.tr("cashier.seller_not_approved.message"));
+            Popup.warn("cashier.seller_not_approved");
             return new HashMap<>();
         }
 
-        // Parse prices (friendly error: tell which token failed)
-        String prices = pricesField.getText();
-        String[] priceStrings = prices.trim().isEmpty() ? new String[0] : prices.trim().split("\\s+");
-        if (priceStrings.length == 0) {
-            Popup.WARNING.showAndWait(
-                    LocalizationManager.tr("cashier.invalid_price.title"),
-                    LocalizationManager.tr("cashier.invalid_price.message"));
+        java.util.List<Integer> prices;
+        try {
+            prices = PriceList.parse(pricesField.getText());
+        } catch (NumberFormatException e) {
+            Popup.warn("cashier.invalid_price");
             return new HashMap<>();
         }
-        Integer[] priceInts = new Integer[priceStrings.length];
-        for (int i = 0; i < priceStrings.length; i++) {
-            String tok = priceStrings[i];
-            if (!tok.matches("\\d+")) {
-                Popup.WARNING.showAndWait(
-                        LocalizationManager.tr("cashier.invalid_price.title"),
-                        LocalizationManager.tr("cashier.invalid_price.message", tok));
-                return new HashMap<>();
-            }
-            priceInts[i] = Integer.parseInt(tok);
-        }
 
-        // Return seller-prices mapping
         Map<Integer, Integer[]> sellerPrices = new HashMap<>();
-        sellerPrices.put(sellerId, priceInts);
+        sellerPrices.put(sellerId, prices.toArray(new Integer[0]));
 
-        // Clear input fields
         sellerField.setText("");
         pricesField.setText("");
 
@@ -358,16 +319,15 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
 
     @Override
     public void clearView() {
-        DefaultTableModel model = getTableModel();
-        model.setRowCount(0); // Clear table
+        SoldItemsTableModel model = getTableModel();
+        model.clear();
         sellerField.setText("");
         pricesField.setText("");
         payedCashField.setText("");
-        changeCashField.setText("");
+        changeValueLabel.setText("");
         sumValue = 0;
         itemsCount = 0;
-        sumLabel.setText(LocalizationManager.tr("cashier.sum", sumValue));
-        noItemsLabel.setText(LocalizationManager.tr("cashier.no_items", itemsCount));
+        updateSummary();
         setFocusToSellerField();
     }
 

--- a/src/main/java/se/goencoder/loppiskassan/ui/CashierTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/CashierTabPanel.java
@@ -91,7 +91,7 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
                 if (e.getKeyCode() == KeyEvent.VK_DELETE) {
                     int row = cashierTable.getSelectedRow();
                     if (row >= 0) {
-                        String itemId = tableModel.getValueAt(row, 2).toString();
+                        String itemId = tableModel.getValueAt(row, SoldItemsTableModel.COLUMN_ITEM_ID).toString();
                         controller.deleteItem(itemId);
                     }
                 }
@@ -169,7 +169,16 @@ public class CashierTabPanel extends JPanel implements CashierPanelInterface, Lo
         payedCashField.addKeyListener(new KeyAdapter() {
             @Override
             public void keyReleased(KeyEvent e) {
-                int payedAmount = payedCashField.getText().isEmpty() ? 0 : Integer.parseInt(payedCashField.getText());
+                int payedAmount = 0;
+                String txt = payedCashField.getText();
+                if (txt != null && !txt.isEmpty()) {
+                    try {
+                        payedAmount = Integer.parseInt(txt);
+                    } catch (NumberFormatException ignore) {
+                        // digit filter should prevent this; fallback to 0 just in case
+                        payedAmount = 0;
+                    }
+                }
                 controller.calculateChange(payedAmount);
             }
         });

--- a/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
@@ -317,7 +317,8 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         cashierCodeLabel = new JLabel();
         cashierCodeField = new JTextField(8);
-        TextFilters.install(cashierCodeField, new TextFilters.DigitsOnlyFilter(8));
+        // Accept codes like "B6I-DKU": A–Z, 0–9 and '-' (auto uppercased), length capped generously
+        TextFilters.install(cashierCodeField, new TextFilters.AlnumDashUpperFilter(16));
         panel.add(cashierCodeLabel);
         panel.add(cashierCodeField);
         return panel;
@@ -656,4 +657,3 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
     }
 
 }
-

--- a/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/DiscoveryTabPanel.java
@@ -287,6 +287,7 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         panel.add(discoveryMarketOwnerStaticLabel, gbc);
         gbc.gridx = 1;
         marketOwnerSplitField = new JTextField(5);
+        TextFilters.install(marketOwnerSplitField, new TextFilters.DigitsOnlyFilter(3));
         panel.add(marketOwnerSplitField, gbc);
 
         // Vendor Split
@@ -296,6 +297,7 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         panel.add(discoveryVendorStaticLabel, gbc);
         gbc.gridx = 1;
         vendorSplitField = new JTextField(5);
+        TextFilters.install(vendorSplitField, new TextFilters.DigitsOnlyFilter(3));
         panel.add(vendorSplitField, gbc);
 
         // Platform Split
@@ -305,6 +307,7 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         panel.add(discoveryPlatformStaticLabel, gbc);
         gbc.gridx = 1;
         platformSplitField = new JTextField(5);
+        TextFilters.install(platformSplitField, new TextFilters.DigitsOnlyFilter(3));
         panel.add(platformSplitField, gbc);
 
         return panel;
@@ -314,6 +317,7 @@ public class DiscoveryTabPanel extends JPanel implements DiscoveryPanelInterface
         JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
         cashierCodeLabel = new JLabel();
         cashierCodeField = new JTextField(8);
+        TextFilters.install(cashierCodeField, new TextFilters.DigitsOnlyFilter(8));
         panel.add(cashierCodeLabel);
         panel.add(cashierCodeField);
         return panel;

--- a/src/main/java/se/goencoder/loppiskassan/ui/EDT.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/EDT.java
@@ -1,0 +1,23 @@
+package se.goencoder.loppiskassan.ui;
+
+import javax.swing.SwingUtilities;
+
+/**
+ * Utility to ensure code runs on the Swing Event Dispatch Thread.
+ */
+public final class EDT {
+    private EDT() {}
+
+    /**
+     * Run the given runnable on the Event Dispatch Thread.
+     *
+     * @param r runnable to execute
+     */
+    public static void run(Runnable r) {
+        if (SwingUtilities.isEventDispatchThread()) {
+            r.run();
+        } else {
+            SwingUtilities.invokeLater(r);
+        }
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/ui/HistoryTabPanel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/HistoryTabPanel.java
@@ -6,6 +6,7 @@ import se.goencoder.loppiskassan.controller.HistoryControllerInterface;
 import se.goencoder.loppiskassan.controller.HistoryTabController;
 import se.goencoder.loppiskassan.localization.LocalizationManager;
 import se.goencoder.loppiskassan.localization.LocalizationAware;
+import se.goencoder.loppiskassan.config.ConfigurationStore;
 
 import javax.swing.*;
 import javax.swing.table.DefaultTableModel;
@@ -326,7 +327,14 @@ public class HistoryTabPanel extends JPanel implements HistoryPanelInterface, Lo
         // Buttons
         eraseAllDataButton.setText(LocalizationManager.tr(BUTTON_ERASE));
         archiveFilteredButton.setText(LocalizationManager.tr("button.archive_filtered"));
-        importDataButton.setText(LocalizationManager.tr(BUTTON_IMPORT));
+        // Ensure the right-hand top button reflects current mode after language switch
+        boolean isOffline = ConfigurationStore.OFFLINE_EVENT_BOOL.getBooleanValueOrDefault(false);
+        if (isOffline) {
+            importDataButton.setText(LocalizationManager.tr(BUTTON_IMPORT)); // e.g., "Import register"
+        } else {
+            // Online: show "Update from Web" (string key must exist in resources)
+            importDataButton.setText(LocalizationManager.tr("history.update_from_web"));
+        }
         payoutButton.setText(LocalizationManager.tr(BUTTON_PAY_OUT));
         toClipboardButton.setText(LocalizationManager.tr(BUTTON_COPY_TO_CLIPBOARD));
 

--- a/src/main/java/se/goencoder/loppiskassan/ui/Renderers.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/Renderers.java
@@ -1,0 +1,23 @@
+package se.goencoder.loppiskassan.ui;
+
+import javax.swing.SwingConstants;
+import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableCellRenderer;
+
+/**
+ * Common table cell renderers.
+ */
+public final class Renderers {
+    private Renderers() {}
+
+    /**
+     * Renderer that right aligns cell contents.
+     *
+     * @return table cell renderer with right alignment
+     */
+    public static TableCellRenderer rightAligned() {
+        DefaultTableCellRenderer r = new DefaultTableCellRenderer();
+        r.setHorizontalAlignment(SwingConstants.RIGHT);
+        return r;
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/ui/SoldItemsTableModel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/SoldItemsTableModel.java
@@ -10,6 +10,11 @@ import java.util.List;
  * Table model for sold items, with typed columns and no cell editing.
  */
 public final class SoldItemsTableModel extends AbstractTableModel {
+    /** Column indices (model indices) for safer cross-file use. */
+    public static final int COLUMN_SELLER  = 0;
+    public static final int COLUMN_PRICE   = 1;
+    public static final int COLUMN_ITEM_ID = 2;
+
     private String[] columns;
     private final List<SoldItem> items = new ArrayList<>();
 
@@ -40,7 +45,7 @@ public final class SoldItemsTableModel extends AbstractTableModel {
     @Override
     public Class<?> getColumnClass(int columnIndex) {
         return switch (columnIndex) {
-            case 0, 1 -> Integer.class;
+            case COLUMN_SELLER, COLUMN_PRICE -> Integer.class;
             default -> String.class;
         };
     }
@@ -49,10 +54,10 @@ public final class SoldItemsTableModel extends AbstractTableModel {
     public Object getValueAt(int rowIndex, int columnIndex) {
         SoldItem item = items.get(rowIndex);
         return switch (columnIndex) {
-            case 0 -> item.getSeller();
-            case 1 -> item.getPrice();
-            case 2 -> item.getItemId();
-            default -> null;
+            case COLUMN_SELLER  -> item.getSeller();
+            case COLUMN_PRICE   -> item.getPrice();
+            case COLUMN_ITEM_ID -> item.getItemId();
+            default             -> null;
         };
     }
 

--- a/src/main/java/se/goencoder/loppiskassan/ui/SoldItemsTableModel.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/SoldItemsTableModel.java
@@ -1,0 +1,83 @@
+package se.goencoder.loppiskassan.ui;
+
+import se.goencoder.loppiskassan.SoldItem;
+
+import javax.swing.table.AbstractTableModel;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Table model for sold items, with typed columns and no cell editing.
+ */
+public final class SoldItemsTableModel extends AbstractTableModel {
+    private String[] columns;
+    private final List<SoldItem> items = new ArrayList<>();
+
+    public SoldItemsTableModel(String[] columnNames) {
+        this.columns = columnNames;
+    }
+
+    public void setColumnNames(String[] columnNames) {
+        this.columns = columnNames;
+        fireTableStructureChanged();
+    }
+
+    @Override
+    public int getRowCount() {
+        return items.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columns.length;
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return columns[column];
+    }
+
+    @Override
+    public Class<?> getColumnClass(int columnIndex) {
+        return switch (columnIndex) {
+            case 0, 1 -> Integer.class;
+            default -> String.class;
+        };
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        SoldItem item = items.get(rowIndex);
+        return switch (columnIndex) {
+            case 0 -> item.getSeller();
+            case 1 -> item.getPrice();
+            case 2 -> item.getItemId();
+            default -> null;
+        };
+    }
+
+    @Override
+    public boolean isCellEditable(int rowIndex, int columnIndex) {
+        return false;
+    }
+
+    /**
+     * Insert item at the top.
+     */
+    public void addItem(SoldItem item) {
+        items.add(0, item);
+        fireTableRowsInserted(0, 0);
+    }
+
+    public void clear() {
+        int size = items.size();
+        if (size > 0) {
+            items.clear();
+            fireTableRowsDeleted(0, size - 1);
+        }
+    }
+
+    public List<SoldItem> getItems() {
+        return items;
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/ui/TextFilters.java
+++ b/src/main/java/se/goencoder/loppiskassan/ui/TextFilters.java
@@ -76,4 +76,33 @@ public final class TextFilters {
             super.replace(fb, 0, fb.getDocument().getLength(), after, a);
         }
     }
+
+    /**
+     * Uppercase alpha-numeric with optional dashes ("-").
+     * Useful for codes like "B6I-DKU". Converts to UPPERCASE automatically.
+     */
+    public static final class AlnumDashUpperFilter extends DocumentFilter {
+        private final int maxLen; // <= 0 means unlimited
+        public AlnumDashUpperFilter(int maxLen) { this.maxLen = maxLen; }
+        private String normalize(String s) {
+            if (s == null) return "";
+            // keep A–Z, a–z, 0–9 and '-'; drop the rest; then uppercase
+            String cleaned = s.replaceAll("[^A-Za-z0-9-]", "");
+            return cleaned.toUpperCase(java.util.Locale.ROOT);
+        }
+        @Override public void insertString(FilterBypass fb, int off, String str, AttributeSet a) throws BadLocationException {
+            if (str == null) return;
+            String before = fb.getDocument().getText(0, fb.getDocument().getLength());
+            String after  = before.substring(0, off) + normalize(str) + before.substring(off);
+            if (maxLen > 0 && after.length() > maxLen) after = after.substring(0, maxLen);
+            super.replace(fb, 0, fb.getDocument().getLength(), after, a);
+        }
+        @Override public void replace(FilterBypass fb, int off, int len, String str, AttributeSet a) throws BadLocationException {
+            String before = fb.getDocument().getText(0, fb.getDocument().getLength());
+            String repl   = (str == null ? "" : normalize(str));
+            String after  = before.substring(0, off) + repl + before.substring(off + len);
+            if (maxLen > 0 && after.length() > maxLen) after = after.substring(0, maxLen);
+            super.replace(fb, 0, fb.getDocument().getLength(), after, a);
+        }
+    }
 }

--- a/src/main/java/se/goencoder/loppiskassan/util/Money.java
+++ b/src/main/java/se/goencoder/loppiskassan/util/Money.java
@@ -1,0 +1,25 @@
+package se.goencoder.loppiskassan.util;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+
+/**
+ * Utility for formatting money amounts without decimals, using locale grouping.
+ */
+public final class Money {
+    private Money() {}
+
+    /**
+     * Format a money amount without decimals using locale aware grouping.
+     *
+     * @param amount amount in whole currency units
+     * @param locale locale for formatting
+     * @param currencyLabel localized currency label (e.g., SEK)
+     * @return formatted string, e.g., "1,234 SEK"
+     */
+    public static String formatAmount(int amount, Locale locale, String currencyLabel) {
+        NumberFormat nf = NumberFormat.getIntegerInstance(locale); // no decimals
+        nf.setGroupingUsed(true);
+        return nf.format(amount) + " " + currencyLabel;
+    }
+}

--- a/src/main/java/se/goencoder/loppiskassan/util/PriceList.java
+++ b/src/main/java/se/goencoder/loppiskassan/util/PriceList.java
@@ -1,0 +1,30 @@
+package se.goencoder.loppiskassan.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Utility for parsing whitespace separated integer price tokens.
+ */
+public final class PriceList {
+    private static final Pattern TOKEN = Pattern.compile("\\d+");
+    private PriceList() {}
+
+    /**
+     * Parse a string of numbers separated by whitespace into a list of integers.
+     *
+     * @param s input string, may not be null or blank
+     * @return list of parsed integers
+     * @throws NumberFormatException if the string is null, blank or contains non-digit tokens
+     */
+    public static List<Integer> parse(String s) throws NumberFormatException {
+        if (s == null || s.isBlank()) throw new NumberFormatException("empty");
+        List<Integer> out = new ArrayList<>();
+        for (String t : s.trim().split("\\s+")) {
+            if (!TOKEN.matcher(t).matches()) throw new NumberFormatException(t);
+            out.add(Integer.parseInt(t));
+        }
+        return out;
+    }
+}

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -12,6 +12,8 @@
   "frame.title": "iLoppis Cash Register v1.0",
   "popup.confirm": "Confirm",
   "popup.cancel": "Cancel",
+  "popup.ok": "OK",
+  "popup.details": "Details",
   "error.create_dirs.title": "Could not create directories",
   "error.create_dirs.message": "Need to create directories 'data' and 'logs' to continue. Ensure the program has permission to create directories.",
   "discovery.selected_event.title": "Selected Event",

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -14,6 +14,7 @@
   "popup.cancel": "Cancel",
   "popup.ok": "OK",
   "popup.details": "Details",
+  "history.update_from_web": "Update from Web",
   "error.create_dirs.title": "Could not create directories",
   "error.create_dirs.message": "Need to create directories 'data' and 'logs' to continue. Ensure the program has permission to create directories.",
   "discovery.selected_event.title": "Selected Event",

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -12,6 +12,8 @@
   "frame.title": "iLoppis Kassahantering v1.0",
   "popup.confirm": "Bekräfta",
   "popup.cancel": "Avbryt",
+  "popup.ok": "OK",
+  "popup.details": "Detaljer",
   "error.create_dirs.title": "Kunde inte skapa kataloger",
   "error.create_dirs.message": "Behöver skapa kataloger 'data' och 'logs' för att fortsätta. Kontrollera att programmet har rättigheter att skapa kataloger.",
   "discovery.selected_event.title": "Vald Loppis",

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -14,6 +14,7 @@
   "popup.cancel": "Avbryt",
   "popup.ok": "OK",
   "popup.details": "Detaljer",
+  "history.update_from_web": "Synka med web",
   "error.create_dirs.title": "Kunde inte skapa kataloger",
   "error.create_dirs.message": "Behöver skapa kataloger 'data' och 'logs' för att fortsätta. Kontrollera att programmet har rättigheter att skapa kataloger.",
   "discovery.selected_event.title": "Vald Loppis",

--- a/src/test/java/se/goencoder/loppiskassan/OfflineFlowTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/OfflineFlowTest.java
@@ -28,10 +28,8 @@ public class OfflineFlowTest {
         @Override public void setFocusToSellerField() {}
         @Override public void enableCheckoutButtons(boolean enable) {}
         @Override public void addSoldItem(SoldItem item) {}
-        @Override public void updateSumLabel(String newText) {}
-        @Override public void updateNoItemsLabel(String newText) {}
-        @Override public void updatePayedCashField(Integer amount) {}
-        @Override public void updateChangeCashField(Integer amount) {}
+        @Override public void setPaidAmount(int amount) {}
+        @Override public void setChange(int amount) {}
         @Override public Map<Integer, Integer[]> getAndClearSellerPrices() { return Map.of(); }
         @Override public void clearView() {}
         @Override public void selected() {}

--- a/src/test/java/se/goencoder/loppiskassan/controller/CashierTabControllerTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/controller/CashierTabControllerTest.java
@@ -1,0 +1,37 @@
+package se.goencoder.loppiskassan.controller;
+
+import org.junit.jupiter.api.Test;
+import se.goencoder.loppiskassan.SoldItem;
+import se.goencoder.loppiskassan.ui.CashierPanelInterface;
+
+import java.awt.Component;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CashierTabControllerTest {
+    static class StubView implements CashierPanelInterface {
+        int change;
+        @Override public void setFocusToSellerField() {}
+        @Override public void enableCheckoutButtons(boolean enable) {}
+        @Override public void addSoldItem(SoldItem item) {}
+        @Override public void setPaidAmount(int amount) {}
+        @Override public void setChange(int amount) { this.change = amount; }
+        @Override public Map<Integer, Integer[]> getAndClearSellerPrices() { return Map.of(); }
+        @Override public void clearView() {}
+        @Override public void selected() {}
+        @Override public Component getComponent() { return null; }
+    }
+
+    @Test
+    void calculateChange() {
+        CashierTabController controller = (CashierTabController) CashierTabController.getInstance();
+        StubView view = new StubView();
+        controller.registerView(view);
+        controller.cancelCheckout();
+        controller.addItem(1, new Integer[]{100, 50});
+        controller.calculateChange(200);
+        assertEquals(50, view.change);
+        controller.cancelCheckout();
+    }
+}

--- a/src/test/java/se/goencoder/loppiskassan/util/MoneyTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/util/MoneyTest.java
@@ -1,0 +1,21 @@
+package se.goencoder.loppiskassan.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MoneyTest {
+    @Test
+    void formatAmountSimple() {
+        String s = Money.formatAmount(205, Locale.US, "SEK");
+        assertEquals("205 SEK", s);
+    }
+
+    @Test
+    void formatAmountGrouping() {
+        String s = Money.formatAmount(12345, Locale.US, "SEK");
+        assertEquals("12,345 SEK", s);
+    }
+}

--- a/src/test/java/se/goencoder/loppiskassan/util/PriceListTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/util/PriceListTest.java
@@ -1,0 +1,26 @@
+package se.goencoder.loppiskassan.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PriceListTest {
+    @Test
+    void parseValid() {
+        List<Integer> list = PriceList.parse("10 20 30");
+        assertEquals(List.of(10, 20, 30), list);
+    }
+
+    @Test
+    void parseInvalid() {
+        assertThrows(NumberFormatException.class, () -> PriceList.parse("10a 20"));
+    }
+
+    @Test
+    void parseSpaces() {
+        List<Integer> list = PriceList.parse("  10  20   30 ");
+        assertEquals(List.of(10, 20, 30), list);
+    }
+}


### PR DESCRIPTION
## Summary
- add reusable PriceList parser and Money formatter to standardize numeric handling
- switch cashier table to typed SoldItemsTableModel with right-aligned rendering and automatic summary updates
- streamline popups, EDT helpers, and digit-only filters across numeric fields

## Testing
- `mvn -B test`
- `mvn -B -DskipTests verify`


------
https://chatgpt.com/codex/tasks/task_e_68a74c81ea24832489809df68d0be837