### PR TITLE
Fix Windows support export and update dependencies

### DIFF
--- a/docs/technical/issues/007-supportbundle-lasta-loggfiler-windows.md
+++ b/docs/technical/issues/007-supportbundle-lasta-loggfiler-windows.md
@@ -1,0 +1,199 @@
+# 007 Supportpaket kan inte skapas med låsta loggfiler i Windows
+
+## Status
+
+Inte påbörjad.
+
+Skapad: 2026-08-13.
+
+## Ägare
+
+Arkitekt/Team Lead (@ripley), Desktop Engineer (@rosemary), Security Reviewer (@ash), Code Reviewer (@wednesday) och E2E Tester (@norman).
+
+## Mål
+
+Det ska gå att skapa en giltig supportfil från en körande Loppiskassan i Windows. Paketet ska innehålla användbara loggar, men inte Java-loggningens låsfiler, och ett fel i en enskild loggfil ska inte lämna kvar ett missvisande eller trasigt ZIP-arkiv.
+
+## Affärsnytta
+
+Vid en driftstörning behöver supporten snabbt få in underlag från kassadatorn. Om supportfilen inte kan skapas medan kassan körs försvinner den avsedda självservicevägen just när den behövs som mest. Manuell filinsamling eller omstart av kassan tar tid, ökar risken att viktig felsökningsinformation tappas och belastar personalen under loppisen.
+
+## Problembeskrivning
+
+`Main.createLogger()` skapar en roterande `java.util.logging.FileHandler` för `loppiskassan.log` med fem generationer och behåller den ansluten till root-loggern under hela programkörningen (`src/main/java/se/goencoder/loppiskassan/Main.java`). Java skapar då normalt datafiler som `loppiskassan.log.0` och en kontroll-/låsfil som `loppiskassan.log.0.lck`.
+
+`DataBundleExporter.collectLogFiles()` väljer i dag alla vanliga filer vars namn börjar med `loppiskassan.log`. Det inkluderar därmed även `.lck`-filen. Därefter kopierar `addFileEntry()` varje vald fil direkt till ZIP-strömmen med `Files.copy(...)` (`src/main/java/se/goencoder/loppiskassan/controller/DataBundleExporter.java`).
+
+Den mest specifika hypotesen är att exporten i Windows försöker läsa den exklusivt låsta `.lck`-filen och avbryts med `IOException`. Den aktiva dataloggen kan också vara låst beroende på JDK-version, filsystem och Windows share mode. Det senare ska verifieras i en reproduktion och inte antas utan evidens.
+
+Nuvarande `DataBundleExporterTest` använder endast en stängd temporär fil med namnet `loppiskassan.log`. Testet täcker varken Java `FileHandler`:s verkliga filnamn eller låsning medan loggningen är aktiv.
+
+## Berörda repos
+
+- `Loppiskassan`
+
+## Berörda områden
+
+- initiering och livscykel för `java.util.logging.FileHandler`
+- urval och ZIP-packning av loggfiler i `DataBundleExporter`
+- felhantering och städning av delvis skapade supportfiler
+- enhets- och integrationstester för supportpaket
+- manuell verifiering på Windows
+- vid behov lokaliserade fel- eller varningstexter på supportsidan
+
+## Avgränsningar
+
+- Ingen uppladdning av supportfilen till en server.
+- Ingen ändring av supportpaketets event- eller konfigurationsdata.
+- Ingen ny loggplattform eller extern loggningsdependency enbart för detta fel.
+- Ingen generell lösning för att läsa godtyckliga filer som låses av andra processer.
+- Ingen implementation ingår i denna issuefil.
+
+## Begränsningar
+
+- Exporten ska fungera medan Loppiskassan fortsätter köra.
+- `.lck` och andra kontrollfiler får aldrig tas med som supportdata.
+- Loggning får inte permanent stängas av eller skapa dubbla handlers efter export.
+- Filnamn och ZIP-innehåll ska vara deterministiska och inte bero på katalogens listningsordning.
+- Källfilerna får inte ändras eller raderas av exporten.
+- En misslyckad export ska rapportera ett begripligt, lokaliserat fel och den ofullständiga ZIP-filen ska tas bort eller aldrig publiceras på den valda slutdestinationen.
+- Ingen ny dependency får läggas till utan separat godkännande.
+
+## Lösningsalternativ
+
+### Alternativ A — strikt urval av riktiga loggfiler (rekommenderad första åtgärd)
+
+Ändra loggurvalet från ett brett `startsWith("loppiskassan.log")` till ett uttryckligt kontrakt för basfilen och numrerade rotationsfiler. Exkludera alltid `.lck`, temporära filer, kataloger och okända suffix. Flusha loggern före export och kopiera de läsbara datafilerna utan att stänga handlern.
+
+Fördelar:
+
+- liten och lågriskfylld kodändring;
+- angriper den mest sannolika direkta orsaken;
+- ingen paus eller omkonfigurering av loggningen;
+- lätt att enhetstesta.
+
+Nackdelar:
+
+- räcker inte om Windows/JDK-konfigurationen även hindrar läsning av den aktiva dataloggen;
+- en loggrad som skrivs samtidigt som filen kopieras kan ge en tidsmässigt inkonsekvent slutpunkt.
+
+Detta alternativ ska väljas om Windows-reproduktionen visar att `.lck` är den enda blockerade filen.
+
+### Alternativ B — kontrollerad checkpoint av `FileHandler`
+
+Gör den aktiva filhandlern till en livscykelhanterad komponent. Vid export: blockera samtidig handler-omkonfigurering, flusha och stäng handlern, skapa supportpaketet från de nu olåsta datafilerna och öppna sedan en ny handler i ett `finally`-block. Exporten bör skrivas till en temporär fil och flyttas atomiskt till användarens valda destination först när den är komplett.
+
+Fördelar:
+
+- ger en tydlig filcheckpoint och fungerar även om den aktiva dataloggen är låst;
+- bevarar befintligt loggformat och rotationsupplägg;
+- kräver ingen ny dependency.
+
+Nackdelar:
+
+- mer riskfylld livscykel- och trådhantering;
+- loggrader kan tappas under det korta intervallet om loggning inte buffras eller serialiseras korrekt;
+- fel vid återöppning kan lämna applikationen utan filloggning och måste därför hanteras explicit.
+
+Detta alternativ ska väljas om Windows-reproduktionen visar att även den aktiva dataloggen inte kan läsas så länge handlern är öppen.
+
+### Alternativ C — best-effort-export med tydlig varning
+
+Exkludera `.lck`, försök kopiera varje tillåten datalogg separat och fortsätt om en fil ger ett lås- eller åtkomstfel. Paketets manifest ska skilja på inkluderade och utelämnade loggar samt ange en säker, icke-känslig felkategori. UI:t ska tydligt säga att supportfilen skapades med en varning. Stängda rotationsgenerationer prioriteras och den aktiva filen försöks sist.
+
+Fördelar:
+
+- en låst fil blockerar inte insamling av eventdata, sanerad konfiguration och läsbara historiska loggar;
+- ingen stängning eller omstart av filloggningen;
+- felutfallet blir synligt för både användare och support.
+
+Nackdelar:
+
+- den senaste och ofta mest relevanta loggen kan saknas;
+- ett partiellt paket kan misstolkas som komplett om manifest och UI-varning inte är entydiga;
+- löser inte grundorsaken och ska därför vara en defensiv fallback, inte enda långsiktiga åtgärd.
+
+Rekommendation: implementera alternativ A och kombinera det med alternativ C som defensiv fallback. Gå vidare med alternativ B endast om Windows-verifieringen visar att den aktiva dataloggen fortfarande inte kan läsas efter att `.lck` har exkluderats.
+
+## Tillämpliga repository-instruktioner
+
+Granskad: `AGENTS.md` i roten av `Loppiskassan`.
+
+- **How to build & test in Codex (Linux/headless):** verifiering i Codex ska köra `make ci`; Swing-applikationen och paketering ska inte startas i den headless miljön.
+- **JDK:** implementation och tester ska använda Java 21.
+- **Decision rule (NO ASSUMPTIONS):** om Windows-reproduktionen inte avgör vilka filer som faktiskt är oläsbara ska detta förbli en öppen fråga; implementationen får inte anta att alla aktiva loggfiler är läsbara.
+- **UI Rules / UI Architecture (Model/View/Controller):** eventuell ny UI-text hör hemma i befintlig Swing-vy, medan export-, fil- och loggerlogik ska ligga utanför UI-komponenterna.
+- **Internationalization — Critical Rules:** alla nya användarsynliga fel och varningar ska hämtas med `LocalizationManager.tr(...)` och finnas i både svensk och engelsk språkfil.
+- **Environment Detection:** den nödvändiga Windows-verifieringen ska köras separat på Windows; CI kan verifiera portabel logik men inte ersätta test av Windows fillåsning.
+- **Dependencies:** lösningsalternativen kräver ingen ny extern dependency.
+
+Inga frontend-, backend-, API-, protobuf-, databas- eller deploymentinstruktioner i de andra iLoppis-repona berörs av denna desktopändring.
+
+## Föreslagen plan
+
+1. **@rosemary** reproducerar felet på en supportad Windows- och JDK 21-miljö och dokumenterar exakt filnamn, undantagstyp och om både `.lck` och den aktiva dataloggen är oläsbara.
+2. **@ripley** fastställer lösningsval och kontraktet för komplett respektive partiellt supportpaket enligt rekommendationen ovan.
+3. **@rosemary** implementerar valt alternativ, strikt filurval, säker hantering av ofullständig ZIP-fil och eventuell loggerlivscykel utan nya dependencies.
+4. **@rosemary** utökar `DataBundleExporterTest` och lägger till avgränsade tester för loggerlivscykeln om alternativ B eller C väljs.
+5. **@ash** granskar att befintlig API-nyckelsanering bevaras och att manifestets felinformation inte läcker logginnehåll, känsliga sökvägar eller autentiseringsdata.
+6. **@wednesday** granskar filmatchning, resursstängning, samtidighet, felvägar och att loggern inte dupliceras eller försvinner efter export.
+7. **@norman** kör regressionstest på Windows medan kassan loggar aktivt samt verifierar ett skapat supportpaket med ett oberoende ZIP-verktyg.
+
+## Teststrategi
+
+### Automatiserade tester
+
+- Skapa realistiska filer som `loppiskassan.log.0`, `loppiskassan.log.1` och `loppiskassan.log.0.lck`; verifiera att endast datafilerna hamnar i ZIP-arkivet och i manifestets `logFiles`.
+- Verifiera att filer med närliggande men ogiltiga namn, exempelvis `.lck`, `.tmp` och `loppiskassan.log.backup`, inte tas med.
+- Verifiera stabil sorteringsordning för rotationsfilerna.
+- Verifiera att ZIP-filen kan läsas och att logginnehållet är oförändrat.
+- Simulera `IOException` under en loggkopiering och verifiera att ingen ofullständig fil presenteras som en lyckad supportfil.
+- Om alternativ B väljs: verifiera flush, close och återöppning även när ZIP-skapandet misslyckas, samt att exakt en aktiv file handler finns efteråt.
+- Om alternativ C väljs: simulera en oläsbar datalogg och verifiera att ZIP-filen fortfarande är giltig, att manifestet exakt redovisar inkluderade och utelämnade loggar och att UI:t visar en lokaliserad varning.
+- Kör hela den headless verifieringen med `make ci`.
+
+### Manuell Windows-verifiering
+
+1. Starta en paketerad Loppiskassan på Windows med JDK 21-runtime och generera loggrader före och under exporten.
+2. Bekräfta att Java har en aktiv `.lck`-fil och dokumentera vilka loggdatafiler som kan respektive inte kan öppnas medan programmet körs.
+3. Skapa supportfilen utan att stänga kassan.
+4. Öppna ZIP-filen med Windows Explorer och ett oberoende ZIP-verktyg.
+5. Bekräfta att manifest, eventdata, sanerad konfiguration och minst en relevant logg finns, att ingen `.lck`-fil finns och att loggning fortsätter efter exporten.
+6. Upprepa export samtidigt som loggrotation sker eller provoceras med reducerad rotationsstorlek i testmiljö.
+
+## Acceptanskriterier
+
+- [ ] En supportfil kan skapas på Windows medan Loppiskassan och filloggningen är aktiva.
+- [ ] ZIP-arkivet innehåller minst en relevant logg med poster från den aktuella körningen.
+- [ ] Ingen fil med suffix `.lck`, `.tmp` eller annat kontrollfilsuffix tas med i ZIP eller manifest.
+- [ ] ZIP-filen är komplett och kan öppnas med både Windows Explorer och ett oberoende ZIP-verktyg.
+- [ ] Loppiskassan fortsätter skriva loggar efter en lyckad export och efter en framtvingad misslyckad export.
+- [ ] Exporten skapar inte dubbla file handlers, tappar inte permanent filloggning och ändrar inte källoggarna.
+- [ ] En misslyckad export visar ett begripligt lokaliserat fel och lämnar inte kvar en fil som kan misstas för ett komplett supportpaket.
+- [ ] Om best-effort-fallback används framgår det entydigt i både manifest och UI vilka loggar som utelämnades, utan att känsliga sökvägar eller logginnehåll exponeras.
+- [ ] Automatiserade regressionstester passerar via `make ci`.
+- [ ] Den slutliga lösningen har verifierats manuellt på en supportad Windows-miljö med aktiv loggrotation.
+
+## Risker och motåtgärder
+
+- **Fel rotorsak antas:** reproduktion på Windows genomförs innan alternativ väljs; exakt blockerad fil och exception dokumenteras.
+- **Loggrader tappas under export:** alternativ A föredras när det räcker. Alternativ B ska serialisera handlerlivscykeln och garantera återöppning i `finally`.
+- **Korrupt eller halvfärdig ZIP:** skriv till en unik temporär fil bredvid destinationen, stäng och validera arkivet och flytta först därefter till slutnamnet.
+- **Rotation sker mitt under kopiering:** testa framtvingad rotation; hantera varje källfil med tydlig felpolicy och låt inte manifestet lova filer som saknas i arkivet.
+- **Känslig information i loggar:** ändra inte nuvarande logginnehåll i denna issue; befintliga loggningsregler gäller och eventuell separat sanering ska säkerhetsgranskas som eget scope.
+- **Plattformsspecifik regression:** behåll portabla enhetstester men kräv dessutom ett verkligt Windows-test eftersom Linux/macOS inte reproducerar samma fillåsning.
+
+## Öppna frågor
+
+1. Är `.lck` den enda fil som utlöser felet i den paketerade Windows-versionen, eller är även den aktiva `loppiskassan.log.0` oläsbar?
+2. Vilka Windows- och paketerade JDK-versioner stöds inför nästa loppis och ska ingå i verifieringsmatrisen?
+3. Ska exporten misslyckas helt om en roterad historisk logg inte kan läsas, eller ska paketet skapas med en tydlig lista över utelämnade loggar i manifestet?
+
+## Definition of done
+
+- Rotorsaken är reproducerad och dokumenterad på Windows.
+- Ett av de tre alternativen är valt med dokumenterad motivering.
+- Acceptanskriterierna och relevanta automatiserade tester är uppfyllda.
+- `make ci` passerar.
+- Manuell Windows-verifiering med aktiv loggning och rotation är godkänd av @norman.
+- Koden är granskad av @wednesday och signerad av @ripley.

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.release>21</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -36,34 +35,46 @@
             <groupId>se.goencoder.iloppis</groupId>
             <artifactId>iloppis-client</artifactId>
             <version>0.0.8</version>
+            <exclusions>
+                <!-- Generated client bytecode uses neither dependency. Exclude stale
+                     OpenAPI-generator boilerplate and its vulnerable transitive chain. -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.openapitools</groupId>
+                    <artifactId>jackson-databind-nullable</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20250517</version>
+            <version>20260719</version>
         </dependency>
 
         <dependency>
             <groupId>org.commonmark</groupId>
             <artifactId>commonmark</artifactId>
-            <version>0.24.0</version>
+            <version>0.30.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf</artifactId>
-            <version>3.6</version>
+            <version>3.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.formdev</groupId>
             <artifactId>flatlaf-extras</artifactId>
-            <version>3.6</version>
+            <version>3.7.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.13.4</version>
+            <version>6.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -73,23 +84,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <release>21</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.3</version>
+                <version>3.5.6</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>3.8.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -126,7 +136,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.6.3</version>
                         <executions>
                             <execution>
                                 <id>package-dmg</id>

--- a/src/main/java/se/goencoder/loppiskassan/controller/DataBundleExporter.java
+++ b/src/main/java/se/goencoder/loppiskassan/controller/DataBundleExporter.java
@@ -14,8 +14,11 @@ import java.awt.Component;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.text.Normalizer;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -24,6 +27,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -35,6 +41,7 @@ public class DataBundleExporter {
     private static final DateTimeFormatter TIMESTAMP_FORMAT =
             DateTimeFormatter.ofPattern("yyyy-MM-dd-HHmmss");
     private static final String DEFAULT_CASHIER_SLUG = "kassa";
+    private static final String LOG_FILE_BASENAME = "loppiskassan.log";
 
     /**
      * Export a support bundle for the selected iLoppis event.
@@ -63,15 +70,26 @@ public class DataBundleExporter {
                 return;
             }
 
-            createBundle(destination.toPath(), eventId, eventName, cashierName);
+            BundleCreationResult result = createBundle(
+                    destination.toPath(), eventId, eventName, cashierName);
 
-            Popup.INFORMATION.showAndWait(
-                    LocalizationManager.tr("support_bundle.success.title"),
-                    LocalizationManager.tr("support_bundle.success.message",
-                            destination.getName(),
-                            destination.getParent(),
-                            cashierName)
-            );
+            if (result.isPartial()) {
+                Popup.WARNING.showAndWait(
+                        LocalizationManager.tr("support_bundle.partial.title"),
+                        LocalizationManager.tr("support_bundle.partial.message",
+                                destination.getName(),
+                                destination.getParent(),
+                                cashierName)
+                );
+            } else {
+                Popup.INFORMATION.showAndWait(
+                        LocalizationManager.tr("support_bundle.success.title"),
+                        LocalizationManager.tr("support_bundle.success.message",
+                                destination.getName(),
+                                destination.getParent(),
+                                cashierName)
+                );
+            }
         } catch (Exception e) {
             Popup.ERROR.showAndWait(
                     LocalizationManager.tr("support_bundle.error.title"),
@@ -106,21 +124,27 @@ public class DataBundleExporter {
         return trimmed;
     }
 
-    static void createBundle(Path zipPath, String eventId, String eventName,
-                             String cashierName) throws IOException {
-        createBundle(zipPath, eventId, eventName, cashierName,
+    static BundleCreationResult createBundle(Path zipPath, String eventId, String eventName,
+                                             String cashierName) throws IOException {
+        return createBundle(zipPath, eventId, eventName, cashierName,
                 LocalEventPaths.getEventDir(eventId),
                 AppPaths.getConfigDir(),
                 AppPaths.getLogsDir());
     }
 
-    static void createBundle(Path zipPath, String eventId, String eventName,
-                             String cashierName, Path eventDir, Path configDir,
-                             Path logsDir) throws IOException {
-        Path parent = zipPath.getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
+    static BundleCreationResult createBundle(Path zipPath, String eventId, String eventName,
+                                             String cashierName, Path eventDir, Path configDir,
+                                             Path logsDir) throws IOException {
+        return createBundle(zipPath, eventId, eventName, cashierName,
+                eventDir, configDir, logsDir, Files::readAllBytes);
+    }
+
+    static BundleCreationResult createBundle(Path zipPath, String eventId, String eventName,
+                                             String cashierName, Path eventDir, Path configDir,
+                                             Path logsDir, LogFileReader logFileReader) throws IOException {
+        Path absoluteZipPath = zipPath.toAbsolutePath();
+        Path parent = absoluteZipPath.getParent();
+        Files.createDirectories(parent);
 
         List<Path> eventFiles = collectExistingFiles(eventDir,
                 "pending_items.jsonl",
@@ -130,33 +154,52 @@ public class DataBundleExporter {
         List<Path> configFiles = collectExistingFiles(configDir,
                 "global.json",
                 "iloppis-mode.json");
-        List<Path> logFiles = collectLogFiles(logsDir);
+        flushActiveFileHandlers();
+        LogCollection logs = snapshotLogFiles(logsDir, logFileReader);
+        Path temporaryZip = Files.createTempFile(parent,
+                "." + absoluteZipPath.getFileName() + "-", ".tmp");
 
-        try (ZipOutputStream zos = new ZipOutputStream(
-                Files.newOutputStream(zipPath), StandardCharsets.UTF_8)) {
-            JSONObject manifest = new JSONObject();
-            manifest.put("cashierName", cashierName);
-            manifest.put("eventId", eventId);
-            manifest.put("eventName", eventName != null ? eventName : "");
-            manifest.put("exportTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
-            manifest.put("format", "iloppis-support-bundle-v1");
-            manifest.put("purpose", "support");
-            manifest.put("eventFiles", toRelativeNames(eventFiles, eventDir));
-            manifest.put("configFiles", toRelativeNames(configFiles, configDir));
-            manifest.put("logFiles", toRelativeNames(logFiles, logsDir));
+        try {
+            try (ZipOutputStream zos = new ZipOutputStream(
+                    Files.newOutputStream(temporaryZip), StandardCharsets.UTF_8)) {
+                JSONObject manifest = new JSONObject();
+                manifest.put("cashierName", cashierName);
+                manifest.put("eventId", eventId);
+                manifest.put("eventName", eventName != null ? eventName : "");
+                manifest.put("exportTime", LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
+                manifest.put("format", "iloppis-support-bundle-v1");
+                manifest.put("purpose", "support");
+                manifest.put("eventFiles", toRelativeNames(eventFiles, eventDir));
+                manifest.put("configFiles", toRelativeNames(configFiles, configDir));
+                manifest.put("logFiles", logs.snapshots().stream()
+                        .map(LogSnapshot::fileName)
+                        .toList());
+                manifest.put("skippedLogFiles", logs.skipped().stream()
+                        .map(skipped -> new JSONObject()
+                                .put("file", skipped.fileName())
+                                .put("reason", skipped.reason()))
+                        .toList());
+                manifest.put("logCollectionStatus", logs.status());
 
-            addTextEntry(zos, "manifest.json", manifest.toString(2));
+                addTextEntry(zos, "manifest.json", manifest.toString(2));
 
-            for (Path file : eventFiles) {
-                addBundleFileEntry(zos, "event/" + file.getFileName(), file);
+                for (Path file : eventFiles) {
+                    addBundleFileEntry(zos, "event/" + file.getFileName(), file);
+                }
+                for (Path file : configFiles) {
+                    addBundleFileEntry(zos, "config/" + file.getFileName(), file);
+                }
+                for (LogSnapshot snapshot : logs.snapshots()) {
+                    addBytesEntry(zos, "logs/" + snapshot.fileName(), snapshot.content());
+                }
             }
-            for (Path file : configFiles) {
-                addBundleFileEntry(zos, "config/" + file.getFileName(), file);
-            }
-            for (Path file : logFiles) {
-                addFileEntry(zos, "logs/" + file.getFileName(), file);
-            }
+
+            moveCompletedBundle(temporaryZip, absoluteZipPath);
+        } finally {
+            Files.deleteIfExists(temporaryZip);
         }
+
+        return new BundleCreationResult(logs.snapshots().size(), logs.skipped().size());
     }
 
     private static int getBundleEntryCount(String eventId) throws IOException {
@@ -192,16 +235,79 @@ public class DataBundleExporter {
     }
 
     private static List<Path> collectLogFiles(Path logsDir) throws IOException {
-        if (Files.notExists(logsDir) || !Files.isDirectory(logsDir)) {
+        if (Files.notExists(logsDir)) {
             return List.of();
+        }
+        if (!Files.isDirectory(logsDir)) {
+            throw new IOException("Log path is not an accessible directory");
         }
 
         try (var stream = Files.list(logsDir)) {
             return stream
-                    .filter(Files::isRegularFile)
-                    .filter(path -> path.getFileName().toString().startsWith("loppiskassan.log"))
-                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .filter(path -> isLogDataFileName(path.getFileName().toString()))
+                    .sorted(Comparator
+                            .comparingInt(DataBundleExporter::logReadPriority)
+                            .thenComparing(path -> path.getFileName().toString()))
                     .toList();
+        }
+    }
+
+    private static int logReadPriority(Path path) {
+        String fileName = path.getFileName().toString();
+        return LOG_FILE_BASENAME.equals(fileName) || (LOG_FILE_BASENAME + ".0").equals(fileName)
+                ? 1
+                : 0;
+    }
+
+    static boolean isLogDataFileName(String fileName) {
+        if (LOG_FILE_BASENAME.equals(fileName)) {
+            return true;
+        }
+        if (!fileName.startsWith(LOG_FILE_BASENAME + ".")) {
+            return false;
+        }
+
+        String suffix = fileName.substring(LOG_FILE_BASENAME.length() + 1);
+        if (suffix.isEmpty()) {
+            return false;
+        }
+        for (String part : suffix.split("\\.", -1)) {
+            if (part.isEmpty() || !part.chars().allMatch(Character::isDigit)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static LogCollection snapshotLogFiles(Path logsDir, LogFileReader logFileReader)
+            throws IOException {
+        List<LogSnapshot> snapshots = new ArrayList<>();
+        List<SkippedLog> skipped = new ArrayList<>();
+        for (Path file : collectLogFiles(logsDir)) {
+            try {
+                snapshots.add(new LogSnapshot(file.getFileName().toString(), logFileReader.read(file)));
+            } catch (IOException e) {
+                String reason = e instanceof AccessDeniedException ? "access_denied" : "io_error";
+                skipped.add(new SkippedLog(file.getFileName().toString(), reason));
+            }
+        }
+        String status;
+        if (snapshots.isEmpty()) {
+            status = "no_logs_included";
+        } else if (!skipped.isEmpty()) {
+            status = "partial";
+        } else {
+            status = "complete";
+        }
+        return new LogCollection(List.copyOf(snapshots), List.copyOf(skipped), status);
+    }
+
+    private static void flushActiveFileHandlers() {
+        Logger rootLogger = Logger.getAnonymousLogger().getParent();
+        for (Handler handler : rootLogger.getHandlers()) {
+            if (handler instanceof FileHandler) {
+                handler.flush();
+            }
         }
     }
 
@@ -214,8 +320,12 @@ public class DataBundleExporter {
     }
 
     private static void addTextEntry(ZipOutputStream zos, String name, String content) throws IOException {
+        addBytesEntry(zos, name, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void addBytesEntry(ZipOutputStream zos, String name, byte[] content) throws IOException {
         zos.putNextEntry(new ZipEntry(name));
-        zos.write(content.getBytes(StandardCharsets.UTF_8));
+        zos.write(content);
         zos.closeEntry();
     }
 
@@ -231,6 +341,36 @@ public class DataBundleExporter {
         zos.putNextEntry(new ZipEntry(name));
         Files.copy(file, zos);
         zos.closeEntry();
+    }
+
+    private static void moveCompletedBundle(Path source, Path destination) throws IOException {
+        try {
+            Files.move(source, destination,
+                    StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    @FunctionalInterface
+    interface LogFileReader {
+        byte[] read(Path path) throws IOException;
+    }
+
+    record BundleCreationResult(int includedLogCount, int skippedLogCount) {
+        boolean isPartial() {
+            return includedLogCount == 0 || skippedLogCount > 0;
+        }
+    }
+
+    private record LogSnapshot(String fileName, byte[] content) {
+    }
+
+    private record SkippedLog(String fileName, String reason) {
+    }
+
+    private record LogCollection(List<LogSnapshot> snapshots, List<SkippedLog> skipped, String status) {
     }
 
     private static boolean shouldSanitizeJson(Path file) {

--- a/src/main/resources/lang/en.json
+++ b/src/main/resources/lang/en.json
@@ -463,6 +463,8 @@
   "support_bundle.button": "\uD83D\uDCE6 Create data file…",
   "support_bundle.success.title": "Data file created!",
   "support_bundle.success.message": "\uD83D\uDCE6 {0}\n\uD83D\uDCC1 {1}\n\nThe file was created for cashier ''{2}''.\n\nSend it to iLoppis support for troubleshooting.",
+  "support_bundle.partial.title": "Data file created with a warning",
+  "support_bundle.partial.message": "\uD83D\uDCE6 {0}\n\uD83D\uDCC1 {1}\n\nThe file was created for cashier ''{2}'', but one or more logs could not be included. Details are available in the manifest.\n\nSend it to iLoppis support for troubleshooting.",
   "support_bundle.error.title": "Could not create data file",
 
   "register.default_name": "Register",

--- a/src/main/resources/lang/sv.json
+++ b/src/main/resources/lang/sv.json
@@ -464,6 +464,8 @@
   "support_bundle.button": "\uD83D\uDCE6 Skapa datafil…",
   "support_bundle.success.title": "Datafil skapad!",
   "support_bundle.success.message": "\uD83D\uDCE6 {0}\n\uD83D\uDCC1 {1}\n\nFilen skapades för kassa ''{2}''.\n\nSkicka filen till iLoppis support för felsökning.",
+  "support_bundle.partial.title": "Datafil skapad med varning",
+  "support_bundle.partial.message": "\uD83D\uDCE6 {0}\n\uD83D\uDCC1 {1}\n\nFilen skapades för kassa ''{2}'', men en eller flera loggar kunde inte tas med. Detaljer finns i manifestet.\n\nSkicka filen till iLoppis support för felsökning.",
   "support_bundle.error.title": "Kunde inte skapa datafil",
 
   "register.default_name": "Kassan",

--- a/src/test/java/se/goencoder/loppiskassan/controller/DataBundleExporterTest.java
+++ b/src/test/java/se/goencoder/loppiskassan/controller/DataBundleExporterTest.java
@@ -4,8 +4,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.FileHandler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -62,6 +68,8 @@ class DataBundleExporterTest {
         Files.writeString(configDir.resolve("iloppis-mode.json"),
                 "{\"eventId\":\"" + eventId + "\",\"apiKey\":\"root-secret\",\"apiBaseUrl\":\"https://example.test\"}\n");
         Files.writeString(logsDir.resolve("loppiskassan.log"), "test log\n");
+        Files.writeString(logsDir.resolve("loppiskassan.log.0.lck"), "locked\n");
+        Files.writeString(logsDir.resolve("loppiskassan.log.backup"), "not a rotated log\n");
 
         Path zipPath = tempDir.resolve("iloppis-support-test-2026-03-24-100000.zip");
 
@@ -123,6 +131,11 @@ class DataBundleExporterTest {
         assertTrue(manifestContent.contains("\"eventId\": \"" + eventId + "\""));
         assertTrue(manifestContent.contains("\"format\": \"iloppis-support-bundle-v1\""));
         assertTrue(manifestContent.contains("\"purpose\": \"support\""));
+        assertTrue(manifestContent.contains("\"logFiles\": [\"loppiskassan.log\"]"));
+        assertTrue(manifestContent.contains("\"skippedLogFiles\": []"));
+        assertTrue(manifestContent.contains("\"logCollectionStatus\": \"complete\""));
+        assertTrue(!manifestContent.contains("loppiskassan.log.0.lck"));
+        assertTrue(!manifestContent.contains("loppiskassan.log.backup"));
         assertTrue(eventMetadataContent.contains("\"eventId\": \"" + eventId + "\""));
         assertTrue(modeConfigContent.contains("\"eventId\": \"" + eventId + "\""));
         assertTrue(eventMetadataContent.contains("\"eventName\": \"Test Loppis\""));
@@ -148,5 +161,152 @@ class DataBundleExporterTest {
                 eventDir, configDir, logsDir);
 
         assertTrue(Files.exists(zipPath));
+    }
+
+    @Test
+    void logFileMatcherOnlyAcceptsBaseAndNumericRotations() {
+        assertTrue(DataBundleExporter.isLogDataFileName("loppiskassan.log"));
+        assertTrue(DataBundleExporter.isLogDataFileName("loppiskassan.log.0"));
+        assertTrue(DataBundleExporter.isLogDataFileName("loppiskassan.log.4"));
+        assertTrue(DataBundleExporter.isLogDataFileName("loppiskassan.log.0.1"));
+        assertTrue(!DataBundleExporter.isLogDataFileName("loppiskassan.log.0.lck"));
+        assertTrue(!DataBundleExporter.isLogDataFileName("loppiskassan.log.tmp"));
+        assertTrue(!DataBundleExporter.isLogDataFileName("loppiskassan.log.backup"));
+        assertTrue(!DataBundleExporter.isLogDataFileName("other.log.0"));
+    }
+
+    @Test
+    void createBundleSkipsUnreadableLogAndRecordsSafeManifestReason() throws Exception {
+        Path eventDir = tempDir.resolve("events").resolve("event-1");
+        Path configDir = tempDir.resolve("config");
+        Path logsDir = tempDir.resolve("logs");
+        Files.createDirectories(eventDir);
+        Files.createDirectories(configDir);
+        Files.createDirectories(logsDir);
+
+        Path activeLog = logsDir.resolve("loppiskassan.log.0");
+        Path rotatedLog = logsDir.resolve("loppiskassan.log.1");
+        Files.writeString(activeLog, "active log\n");
+        Files.writeString(rotatedLog, "rotated log\n");
+
+        Path zipPath = tempDir.resolve("partial-support.zip");
+        DataBundleExporter.BundleCreationResult result = DataBundleExporter.createBundle(
+                zipPath, "event-1", "Test Loppis", "Kassa-1",
+                eventDir, configDir, logsDir,
+                path -> {
+                    if (path.equals(activeLog)) {
+                        throw new AccessDeniedException(path.toString(), null, "simulated lock");
+                    }
+                    return Files.readAllBytes(path);
+                });
+
+        assertTrue(result.isPartial());
+        assertEquals(1, result.skippedLogCount());
+
+        Map<String, String> entries = readTextEntries(zipPath);
+        assertEquals("rotated log\n", entries.get("logs/loppiskassan.log.1"));
+        assertTrue(!entries.containsKey("logs/loppiskassan.log.0"));
+
+        String manifest = entries.get("manifest.json");
+        assertNotNull(manifest);
+        assertTrue(manifest.contains("\"file\": \"loppiskassan.log.0\""));
+        assertTrue(manifest.contains("\"reason\": \"access_denied\""));
+        assertTrue(manifest.contains("\"logCollectionStatus\": \"partial\""));
+        assertTrue(!manifest.contains(activeLog.toString()));
+        assertTrue(!manifest.contains("simulated lock"));
+    }
+
+    @Test
+    void createBundleWithActiveFileHandlerExcludesLockFile() throws Exception {
+        Path eventDir = tempDir.resolve("events").resolve("event-1");
+        Path configDir = tempDir.resolve("config");
+        Path logsDir = tempDir.resolve("logs");
+        Files.createDirectories(eventDir);
+        Files.createDirectories(configDir);
+        Files.createDirectories(logsDir);
+
+        Logger rootLogger = Logger.getAnonymousLogger().getParent();
+        FileHandler handler = new FileHandler(
+                logsDir.resolve("loppiskassan.log").toString(), 1_400_000, 5, true);
+        handler.setFormatter(new SimpleFormatter());
+        rootLogger.addHandler(handler);
+        String marker = "active-file-handler-marker";
+
+        try {
+            rootLogger.info(marker);
+
+            Path zipPath = tempDir.resolve("active-handler-support.zip");
+            DataBundleExporter.BundleCreationResult result = DataBundleExporter.createBundle(
+                    zipPath, "event-1", "Test Loppis", "Kassa-1",
+                    eventDir, configDir, logsDir);
+
+            assertTrue(!result.isPartial());
+            Map<String, String> entries = readTextEntries(zipPath);
+            assertTrue(entries.keySet().stream().noneMatch(name -> name.endsWith(".lck")));
+            assertTrue(entries.entrySet().stream()
+                    .filter(entry -> entry.getKey().startsWith("logs/"))
+                    .anyMatch(entry -> entry.getValue().contains(marker)));
+        } finally {
+            rootLogger.removeHandler(handler);
+            handler.close();
+        }
+    }
+
+    @Test
+    void createBundleWithoutLogsIsReportedAsPartial() throws Exception {
+        Path eventDir = tempDir.resolve("events").resolve("event-1");
+        Path configDir = tempDir.resolve("config");
+        Path logsDir = tempDir.resolve("logs");
+        Files.createDirectories(eventDir);
+        Files.createDirectories(configDir);
+        Files.createDirectories(logsDir);
+
+        Path zipPath = tempDir.resolve("no-logs-support.zip");
+        DataBundleExporter.BundleCreationResult result = DataBundleExporter.createBundle(
+                zipPath, "event-1", "Test Loppis", "Kassa-1",
+                eventDir, configDir, logsDir);
+
+        assertTrue(result.isPartial());
+        assertEquals(0, result.includedLogCount());
+        String manifest = readTextEntries(zipPath).get("manifest.json");
+        assertNotNull(manifest);
+        assertTrue(manifest.contains("\"logCollectionStatus\": \"no_logs_included\""));
+    }
+
+    @Test
+    void closedRotationsAreReadBeforeActiveLog() throws Exception {
+        Path eventDir = tempDir.resolve("events").resolve("event-1");
+        Path configDir = tempDir.resolve("config");
+        Path logsDir = tempDir.resolve("logs");
+        Files.createDirectories(eventDir);
+        Files.createDirectories(configDir);
+        Files.createDirectories(logsDir);
+        Files.writeString(logsDir.resolve("loppiskassan.log.0"), "active\n");
+        Files.writeString(logsDir.resolve("loppiskassan.log.1"), "rotated\n");
+
+        java.util.List<String> readOrder = new java.util.ArrayList<>();
+        DataBundleExporter.createBundle(
+                tempDir.resolve("ordered-support.zip"),
+                "event-1", "Test Loppis", "Kassa-1",
+                eventDir, configDir, logsDir,
+                path -> {
+                    readOrder.add(path.getFileName().toString());
+                    return Files.readAllBytes(path);
+                });
+
+        assertEquals(java.util.List.of("loppiskassan.log.1", "loppiskassan.log.0"), readOrder);
+    }
+
+    private static Map<String, String> readTextEntries(Path zipPath) throws Exception {
+        Map<String, String> entries = new HashMap<>();
+        try (ZipInputStream zis = new ZipInputStream(
+                Files.newInputStream(zipPath), StandardCharsets.UTF_8)) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                entries.put(entry.getName(), new String(zis.readAllBytes(), StandardCharsets.UTF_8));
+                zis.closeEntry();
+            }
+        }
+        return entries;
     }
 }


### PR DESCRIPTION
## Sammanfattning

- fixar supportpaketets loggexport på Windows genom att exkludera Java `FileHandler`-låsfiler
- skapar ett tydligt markerat partiellt paket om en logg inte kan läsas
- publicerar ZIP via temporär fil så att misslyckad export inte lämnar ett trasigt slutarkiv
- uppdaterar Loppiskassans direkta Maven-dependencies och stabila buildplugins
- tar bort oanvända, sårbara transitiva dependencies från den kontraktsbundna API-klienten

## Windows-fixen

`DataBundleExporter.collectLogFiles()` använde tidigare `startsWith("loppiskassan.log")` och matchade därför även `loppiskassan.log.0.lck`, som hålls låst medan Loppiskassan kör.

Nu tas endast basloggen och numeriska rotationer med. Stängda rotationer läses före den aktiva loggen. Manifestet redovisar inkluderade och utelämnade loggar med säkra felkategorier och `logCollectionStatus`.

Fixen har verifierats manuellt på Windows av användaren. Alternativ B med kontrollerad stängning/återöppning av `FileHandler` behövs därför inte nu.

## Dependencyuppdateringar

- `org.json:json` 20250517 → 20260719
- `org.commonmark:commonmark` 0.24.0 → 0.30.0
- `flatlaf` och `flatlaf-extras` 3.6 → 3.7.2
- `junit-jupiter` 5.13.4 → 6.1.3
- `maven-compiler-plugin` 3.14.0 → 3.15.0
- `maven-surefire-plugin` 3.5.3 → 3.5.6
- `maven-assembly-plugin` 3.7.1 → 3.8.0
- `exec-maven-plugin` 3.5.0 → 3.6.3
- compiler-konfigurationen använder nu `release 21`

`iloppis-client` ligger kvar på kontraktsbundna 0.0.8. Bytecode- och källkodsgranskning visade att dess POM drog in oanvända `commons-lang3` och `jackson-databind-nullable` inklusive en gammal Jackson-kedja. De exkluderas nu utan att klient-JAR:en eller API-kontraktet ändras.

## Verifiering

- manuell Windows-verifiering av supportexport: godkänd
- `mvn -B -P!mac-installer clean verify`
- 81 tester, 0 failures, 0 errors
- JAR och jar-with-dependencies byggda
- `mvn dependency:tree`: exkluderade Commons Lang/Jackson-dependencies saknas
- `versions:display-dependency-updates`: inga kvarvarande direkta uppdateringar
- svenska och engelska språkfiler JSON-validerade
- `git diff --check`
